### PR TITLE
fix: add typecheck to logger to allow redux-thunk

### DIFF
--- a/app/components/Panel.js
+++ b/app/components/Panel.js
@@ -90,7 +90,8 @@ export default class Panel extends Component {
 
           const logger = (logItem) => {
             // Only log Apollo actions for now
-            if (logItem.action.type.split('_')[0] !== 'APOLLO') {
+            // type check 'type' to avoid issues with thunks and other middlewares
+            if (typeof logItem.action.type !== 'string' || logItem.action.type.split('_')[0] !== 'APOLLO') {
               return;
             }
 


### PR DESCRIPTION
For actions that return redux-thunks, Apollo-client-devtools middleware was throwing a breaking error `Cannot call function "split" of undefined`. 
This type check avoids any error where type does not exist or is not a string.
[example](https://cloud.githubusercontent.com/assets/563568/22762129/0b47a8f4-ee1b-11e6-8281-73051e9b9dd9.png)
