### PR TITLE
Fix error running in electron app.

### DIFF
--- a/extension/hook.js
+++ b/extension/hook.js
@@ -1,4 +1,5 @@
-const version = chrome.runtime.getManifest().version;
+const getManifest = chrome.runtime.getManifest;
+const version = (getManifest && getManifest().version) || 'electron-version';
 const js = ` window.__APOLLO_DEVTOOLS_GLOBAL_HOOK__ = { version: "${version}" }; `;
 
 var script = document.createElement('script');


### PR DESCRIPTION
Fix error while used within Electron app - in which chrome.runtime.getManifest() is not defined.

<img width="722" alt="screen shot 2017-03-27 at 10 12 36" src="https://cloud.githubusercontent.com/assets/1032524/24360857/71836196-12d6-11e7-9ee2-a5986aa928ad.png">
