### PR TITLE
Added a mutations tab to track mutations

### DIFF
--- a/app/components/Explorer/Explorer.js
+++ b/app/components/Explorer/Explorer.js
@@ -108,7 +108,9 @@ export default class Explorer extends Component {
   componentDidMount() {
     if (ga) ga('send', 'pageview', 'GraphiQL');
     if (this.props.query) {
-      this.graphiql.handleRunQuery();
+      if(this.props.automaticallyRunQuery) {
+        this.graphiql.handleRunQuery();
+      }
     }
   }
 

--- a/app/components/Mutations/Mutations.less
+++ b/app/components/Mutations/Mutations.less
@@ -1,0 +1,260 @@
+.dark {
+  .mutations {
+    color: #FFF;
+
+    .sidebar {
+      border-right-color: rgb(61, 61, 61);
+
+      .mutations-sidebar-title {
+        background-color: #2a2a2a;
+        border-bottom-color: rgb(61, 61, 61);
+        color: #FFF !important;
+      }
+    }
+
+    .main {
+      table {
+        tr {
+          color: #CCC;
+        }
+      }
+
+      .component-name {
+        color: #c678dd !important; // TODO
+      }
+
+      .GraphqlCodeBlock span.comment {
+        color: #CCC;
+      }
+
+      .GraphqlCodeBlock span.number {
+        color: rgb(93, 176, 215);
+      }
+
+      .GraphqlCodeBlock span.variable {
+        color: rgb(53, 212, 199);
+      }
+
+      .GraphqlCodeBlock span.atom {
+        color: rgb(242, 151, 102);
+      }
+
+      .GraphqlCodeBlock span.attribute {
+        color: #c678dd;
+      }
+
+      .GraphqlCodeBlock span.punctuation {
+        color: #CCCCCC;
+      }
+
+      .GraphqlCodeBlock span.keyword {
+        color: rgb(231, 194, 111);
+      }
+
+      .GraphqlCodeBlock span.def {
+        color: hsl(0, 100%, 75%);
+      }
+
+      .GraphqlCodeBlock span.property {
+        color: rgb(155, 187, 220);
+      }
+    }
+  }
+}
+
+.mutations {
+  display: flex;
+  flex-direction: row;
+
+  .sidebar {
+    flex: none;
+    width: 200px;
+    border-right: 1px solid #DDD;
+
+    .mutations-sidebar-title {
+      font-weight: bold;
+      background-color: #FBFBFB;
+      border-bottom: 1px solid #CCC;
+      line-height: 33px;
+      padding-left: 10px;
+
+      // support dev-tools dark theme
+      .apollo-client-panel.dark & {
+        color: #333333;
+      }
+    }
+
+    .mutation-list {
+      padding: 0 0 0 25px;
+      margin: 0;
+
+      .item {
+        padding: 10px 10px 0;
+        font-size: 12px;
+        cursor: pointer;
+        transition: .25s;
+
+        &:hover {
+          span { color: fade(#333, 60%); }
+
+          // support dev-tools dark theme
+          .apollo-client-panel.dark & {
+            span { color: fade(#ffffff, 60%); }
+          }
+        }
+
+        &.active {
+          span { color: #22a699; }
+
+          &:hover {
+            span { color: fade(#22a699, 60%); }
+          }
+        }
+
+        &.loading {
+          span { color: #AAA; }
+        }
+
+        .item-row {
+          display: inline-flex;
+          justify-content: space-between;
+          align-items: center;
+          width: 100%;
+
+          span {
+            max-width: 95%;
+            word-wrap: break-word;
+          }
+
+          .error-icon {
+            width: 16px;
+            height: 16px;
+          }
+        }
+
+      }
+    }
+  }
+
+  .main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+
+    .toggled-section {
+      margin-bottom: 10px;
+
+      &:last-of-type {
+        margin: 0;
+      }
+
+      table {
+        tr {
+          font-size: 12px;
+
+          // support dev-tools dark theme
+          .apollo-client-panel.dark & {
+            color: #dddddd;
+          }
+
+          td:first-child {
+            font-weight: bold;
+            padding: 0 15px 0 5px;
+          }
+
+          td:nth-child(2) {
+            font-family: monospace;
+          }
+        }
+      }
+    }
+
+    .panel-title {
+      font-size: 14px;
+      margin-bottom: 10px;
+
+      .loading-label {
+        font-size: 12px;
+        font-family: sans-serif;
+        margin-left: 10px;
+        color: #AAA;
+        opacity: 0;
+        transition: .25s;
+
+        &.show {
+          opacity: 1;
+        }
+      }
+
+      .component-name {
+        color: #8B2BB9;
+        font-weight: normal;
+        font-family: monospace;
+        margin-left: 10px;
+      }
+
+      .show-in-graphiql-link {
+        font-size: 10px;
+        cursor: pointer;
+        font-family: sans-serif;
+        margin-left: 10px;
+        padding: 2px 5px;
+        border-radius: 3px;
+        border: 1px solid #CCC;
+
+        &:hover {
+          box-shadow: inset 6px 6px 30px #CCC;
+        }
+      }
+    }
+
+    pre {
+      border: none;
+      font-family: monospace;
+      font-size: 12px;
+    }
+
+    .loading {
+      background: #AAA;
+    }
+
+    .graphql-error {
+      white-space: pre-wrap;
+      font-family: Menlo, Monaco, Consolas, monospace;
+    }
+  }
+
+  .toggle {
+    font-size: 12px;
+    font-weight: bold;
+    cursor: pointer;
+    display: block;
+
+    .triangle {
+      width: 15px;
+      display: inline-block;
+      transition: 300ms all cubic-bezier(0.175, 0.885, 0.335, 1.05);
+      line-height: 15px;
+      vertical-align: top;
+      text-align: center;
+
+      &.toggled {
+        transform: rotate(-90deg);
+      }
+    }
+
+    .section-label {
+      line-height: 15px;
+      display: inline-block;
+      vertical-align: top;
+    }
+
+    &:hover .section-label {
+      text-decoration: underline;
+    }
+  }
+
+  .labeled {
+    padding-left: 16px;
+  }
+}

--- a/app/components/Mutations/index.js
+++ b/app/components/Mutations/index.js
@@ -1,0 +1,2 @@
+import Mutations from './Mutations';
+export default Mutations;

--- a/app/components/Panel.js
+++ b/app/components/Panel.js
@@ -1,7 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
+import { getMutationDefinition } from 'apollo-client';
 
 import WatchedQueries from './WatchedQueries';
+import Mutations from './Mutations';
 import Explorer from './Explorer';
 import Inspector from './Inspector';
 import Apollo from './Images/Apollo';
@@ -34,6 +36,7 @@ export default class Panel extends Component {
       runQuery: undefined,
       runVariables: undefined,
       selectedRequestId: undefined,
+      automaticallyRunQuery: undefined
     };
 
     this.onRun = this.onRun.bind(this);
@@ -143,12 +146,13 @@ export default class Panel extends Component {
     return this.state.actionLog[this.state.actionLog.length - 1];
   }
 
-  onRun(queryString, variables) {
-    ga('send', 'event', 'WatchedQueries', 'run-in-graphiql');
+  onRun(queryString, variables, tab, automaticallyRunQuery) {
+    ga('send', 'event', tab, 'run-in-graphiql');
     this.setState({
       active: 'graphiql',
       runQuery: queryString,
       runVariables: variables ? JSON.stringify(variables, null, 2) : '',
+      automaticallyRunQuery
     });
   }
 
@@ -179,11 +183,15 @@ export default class Panel extends Component {
       // XXX this won't work in the dev tools
       body = selectedLog && <WatchedQueries state={selectedLog.state} onRun={this.onRun}/>;
       break;
+    case 'mutations':
+      // XXX this won't work in the dev tools
+      body = selectedLog && <Mutations state={selectedLog.state} onRun={this.onRun}/>;
+      break;
     case 'store':
       body = selectedLog && <Inspector />;
       break;
     case 'graphiql':
-      body = <Explorer query={this.state.runQuery} variables={this.state.runVariables}/>;
+      body = <Explorer query={this.state.runQuery} variables={this.state.runVariables} automaticallyRunQuery={this.state.automaticallyRunQuery} />;
       break;
     case 'logger':
       body = <Logger
@@ -209,6 +217,11 @@ export default class Panel extends Component {
             className={classnames('tab', { active: active === 'queries' })}
             onClick={() => this.switchPane('queries')}
           ><Queries /><div>Queries</div></div>
+          { getMutationDefinition && <div
+            title="Watched mutations"
+            className={classnames('tab', { active: active === 'mutations' })}
+            onClick={() => this.switchPane('mutations')}
+          ><Queries /><div>Mutations</div></div> }
           <div
             title="Apollo client store"
             className={classnames('tab', { active: active === 'store' })}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack": "^1.13.3"
   },
   "dependencies": {
-    "apollo-client": "^0.5.12",
+    "apollo-client": "^1.4.2",
     "graphql-syntax-highlighter-react": "^0.1.0",
     "graphql-tag": "^1.1.2",
     "lodash": "^4.17.2",


### PR DESCRIPTION
I thought it would be cool to track mutations via the devtools so I copied the queries section and modified it to deal with mutations.

You can find the discussion about this here https://github.com/apollographql/apollo-client-devtools/issues/35

Note this is dependent on a change to the client. I will be pushing up the PR for that now. The specific change is to expose `getMutationDefinition` so that I can retrieve the definition of the mutation from the AST.