### PR TITLE
Sleep for 1 second between data updates

### DIFF
--- a/app/components/Inspector/Inspector.js
+++ b/app/components/Inspector/Inspector.js
@@ -63,13 +63,20 @@ export default class Inspector extends React.Component {
   componentDidMount() {
     if (ga) ga('send', 'pageview', 'StoreInspector');
     this.updateData();
-    this._interval = setInterval(() => {
-      this.updateData();
+    
+    const updater = () => this._interval = setTimeout(() => {
+      try {
+        this.updateData();
+      } finally {
+        updater();
+      }
     }, 1000);
+    
+    updater();
   }
 
   componentWillUnmount() {
-    clearInterval(this._interval);
+    clearTimeout(this._interval);
   }
 
   getChildContext() {


### PR DESCRIPTION
Rather than using setInterval which can queue up and run back to back, using setTimeout AFTER the data is updated allows giving the browser 1 second to do other work. This also means that if evens are backed up you have at most 1 update cycle before browser events are handled again instead of the time getting longer and longer as the interval's queue up.

Note this is untested.