### PR TITLE
Updated styles for Chrome dark mode

### DIFF
--- a/app/components/Inspector/inspector.less
+++ b/app/components/Inspector/inspector.less
@@ -1,4 +1,5 @@
 .dark .inspector-panel {
+  background-color: #333333;
   color: #FFF;
 
   .inspector-sidebar {

--- a/app/components/WatchedQueries/WatchedQueries.less
+++ b/app/components/WatchedQueries/WatchedQueries.less
@@ -1,9 +1,12 @@
 .dark {
   .watchedQueries {
+    background-color: #333333;
     color: #FFF;
 
     .sidebar {
       border-right-color: rgb(61, 61, 61);
+      border-left: 1px solid rgb(61, 61, 61);
+      background-color: #2a2a2a;
 
       .queries-sidebar-title {
         background-color: #2a2a2a;
@@ -13,6 +16,8 @@
     }
 
     .main {
+      background-color: #333333;
+
       table {
         tr {
           color: #CCC;


### PR DESCRIPTION
Addresses #48 

This adds a special case to `.dark` to fill in the background color with `#333333` instead of `white`. See screenshots below:

<img width="1061" alt="screen shot 2017-06-27 at 8 02 30 pm" src="https://user-images.githubusercontent.com/6325382/27618915-d4953e72-5b73-11e7-9a24-2294bb382174.png">

<img width="1033" alt="screen shot 2017-06-27 at 8 02 42 pm" src="https://user-images.githubusercontent.com/6325382/27618916-d638ee54-5b73-11e7-8d57-ac25a6108f37.png">

<img width="1022" alt="screen shot 2017-06-27 at 8 03 00 pm" src="https://user-images.githubusercontent.com/6325382/27618919-da343cb6-5b73-11e7-94e6-60fe19d3fcd1.png">
