### PR TITLE
Updating polling in both Panel and Inspector to wait for the previous polling result to have finished

### DIFF
--- a/app/components/Inspector/Inspector.js
+++ b/app/components/Inspector/Inspector.js
@@ -67,9 +67,7 @@ export default class Inspector extends React.Component {
     if (ga) ga('send', 'pageview', 'StoreInspector');
     this.updateData();
     const updater = () => this._interval = setTimeout(() => {
-      this.updateData().then(() => {
-        updater();
-      })
+      this.updateData().catch(console.error).then(updater)
     }, 1000);
     
     updater();

--- a/app/components/Panel.js
+++ b/app/components/Panel.js
@@ -92,9 +92,7 @@ export default class Panel extends Component {
   componentDidMount() {
     this.lastActionId = null;
     const updater = () => this._interval = setTimeout(() => {
-      this.updateData().then(()=>{
-        updater();
-      })
+      this.updateData().catch(console.error).then(updater)
     }, 1000);
     
     updater();

--- a/app/components/Panel.js
+++ b/app/components/Panel.js
@@ -91,15 +91,11 @@ export default class Panel extends Component {
   }
   componentDidMount() {
     this.lastActionId = null;
-    let lasttime = Date.now()
     const updater = () => this._interval = setTimeout(() => {
-      const newTime = Date.now()
-      console.log('polling! time from last = ',newTime-lasttime)
-      lasttime = newTime
       this.updateData().then(()=>{
         updater();
       })
-    }, 100);
+    }, 1000);
     
     updater();
     this.initLogger();


### PR DESCRIPTION
Yay! With some more poking around at how the polling was working, I think I've come up with a solution that finally fixes the apollo devtools from crashing my browser tab. 

I realized that polling is not just happening in `Inspector.js`, but also `Panel.js`  (note the rapidly incrementing "polling!" console.log in the gif below:
![asdfasdfasd](https://user-images.githubusercontent.com/2730609/27627072-532d0334-5b9f-11e7-9c5e-f49139f36958.gif)

As well as incrementing the default polling interval in Panel.js to 1000 (similar to the change already implemented for Inspector.js), I've also promisified the polling in both places (I'm not 100% sure that the window communication is async but it is using callbacks so I believe it is) and used the trick @thomassuckow employed in his closed PR of calling a new setInterval only after invoking the polling. 

The end result of this is that now polling in both Panel and Inspector to wait for the previous polling result to have finished! Here's a gif of the polling occurring only after it has finished:

![timing](https://user-images.githubusercontent.com/2730609/27627638-63bc7052-5ba1-11e7-9753-dcfa838fe019.gif)

To view the above console logs you can checkout the previous of the 2 commits :)
