### PR TITLE
Graphiql upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-preset-react": "^6.16.0",
     "classnames": "^2.2.5",
     "css-loader": "^0.26.1",
-    "graphiql": "^0.8.0",
+    "graphiql": "^0.11.2",
     "graphql": "^0.7.0",
     "html-webpack-plugin": "^2.24.1",
     "json-loader": "^0.5.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+var webpack = require('webpack')
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var HTMLWebpackPluginConfig = new HtmlWebpackPlugin({
   template: __dirname + '/app/index.html',
@@ -33,5 +34,8 @@ module.exports = {
       }
     ]
   },
-  plugins: [HTMLWebpackPluginConfig]
+  plugins: [
+    HTMLWebpackPluginConfig,
+    new webpack.IgnorePlugin(/\.flow$/)
+  ]
 }


### PR DESCRIPTION
This updates GraphiQL, addressing #54.

Finally unblocked on updating it by this issue: https://github.com/graphql/graphql-language-service/issues/111

### Summary of changes
* Update GraphiQL version in`package.json`
* Ignore `.flow` files in Webpack, because for some reason new version of GraphiQL tries to bundle them