### PR TITLE
Attempt to make Apollo panel creation more reliable

### DIFF
--- a/extension/devtools.js
+++ b/extension/devtools.js
@@ -28,10 +28,10 @@ function createPanel() {
   );
 }
 
-// Attempte to create Apollo panel on navigations as well
+// Attempt to create Apollo panel on navigations as well
 chrome.devtools.network.onNavigated.addListener(createPanel);
 
-// Attempte to create Apollo panel once per second in case
+// Attempt to create Apollo panel once per second in case
 // Apollo is loaded after page load
 const loadCheckInterval = setInterval(createPanel, 1000);
 

--- a/extension/devtools.js
+++ b/extension/devtools.js
@@ -1,15 +1,39 @@
-chrome.devtools.inspectedWindow.eval(`!!(window.__APOLLO_CLIENT__)`, function(
-  result,
-  isException
-) {
-  if (result) {
-    chrome.devtools.panels.create(
-      'Apollo',
-      './imgs/logo_devtools.png',
-      'dist/index.html',
-      function(panel) {}
-    );
-  } else {
-    if (isException) console.warn(isException);
+let panelCreated = false;
+
+function createPanel() {
+  if (panelCreated) {
+    return;
   }
-});
+
+  chrome.devtools.inspectedWindow.eval(
+    `!!(window.__APOLLO_CLIENT__);`,
+    function(result, isException) {
+      if (isException) {
+        console.warn(isException);
+      }
+
+      if (!result || panelCreated) {
+        return;
+      }
+
+      panelCreated = true;
+      clearInterval(loadCheckInterval);
+      chrome.devtools.panels.create(
+        'Apollo',
+        './imgs/logo_devtools.png',
+        'dist/index.html',
+        function(panel) {}
+      );
+    }
+  );
+}
+
+// Attempte to create Apollo panel on navigations as well
+chrome.devtools.network.onNavigated.addListener(createPanel);
+
+// Attempte to create Apollo panel once per second in case
+// Apollo is loaded after page load
+const loadCheckInterval = setInterval(createPanel, 1000);
+
+// Start the first attempt immediately
+createPanel();

--- a/extension/devtools.js
+++ b/extension/devtools.js
@@ -1,4 +1,5 @@
 let panelCreated = false;
+let loadCheckInterval;
 
 function createPanel() {
   if (panelCreated) {
@@ -16,8 +17,10 @@ function createPanel() {
         return;
       }
 
+      if (loadCheckInterval) {
+        clearInterval(loadCheckInterval);
+      }
       panelCreated = true;
-      clearInterval(loadCheckInterval);
       chrome.devtools.panels.create(
         'Apollo',
         './imgs/logo_devtools.png',
@@ -33,7 +36,7 @@ chrome.devtools.network.onNavigated.addListener(createPanel);
 
 // Attempt to create Apollo panel once per second in case
 // Apollo is loaded after page load
-const loadCheckInterval = setInterval(createPanel, 1000);
+loadCheckInterval = setInterval(createPanel, 1000);
 
 // Start the first attempt immediately
 createPanel();


### PR DESCRIPTION
fixes #29 (hopefully 🤞 )

Using this locally the Apollo panel was created much more reliably. I pattern matched off React devtools [panel creation logic](https://github.com/facebook/react-devtools/blob/master/shells/webextension/src/main.js) as I've never had an issue with the React devtool not showing up 😄 