### PR TITLE
Removes Broken Firefox Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Apollo Client Devtools
 ===
 
-[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) | [Download for Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-client-dev-tools/)
+[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm)
 
 This repository contains the Apollo DevTools extension for Chrome & Firefox.
 


### PR DESCRIPTION
https://addons.mozilla.org/en-US/firefox/addon/apollo-client-dev-tools/ currently points to a 404. This is a little confusing to have a broken link here. I didn't see that the Firefox dev tools had been released yet anywhere, so I think it's best to pull the link until it's up and working.