### PR TITLE
Fix #75 #64 #58

### DIFF
--- a/extension/hook.js
+++ b/extension/hook.js
@@ -19,7 +19,7 @@ const hookLogger = (logItem) => {
     }
     
     try {
-      window.postMessage({ newStateData }, '*');  
+      window.postMessage(JSON.parse(JSON.stringify({ newStateData })), '*');  
     }
     catch(err) {
       console.log(err);


### PR DESCRIPTION
This will create a full deep clone of the object before passing it to `postMessage`. This will fix #75, #64 and #58.

Technical information:
We use the `JSON.parse(JSON.stringify(obj))` trick to do a deep clone of the object.
It's the fastest way to deep clone an object, see https://stackoverflow.com/questions/122102/what-is-the-most-efficient-way-to-deep-clone-an-object-in-javascript
  