### PR TITLE
Remove broken link to Firefox dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo Client Devtools
 
-[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) | [Download for Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-client-dev-tools/)
+[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm)
 
 This repository contains the Apollo DevTools extension for Chrome & Firefox.
 


### PR DESCRIPTION
As far as I can tell Apollo dev tools doesn't exist for Firefox, so I'm removing the link