### PR TITLE
Update vendored graphiql styles and fix a z-index bug

### DIFF
--- a/src/devtools/components/Explorer/graphiql.less
+++ b/src/devtools/components/Explorer/graphiql.less
@@ -1,10 +1,7 @@
-.graphiql-container {
+.graphiql-container,
+.graphiql-container button,
+.graphiql-container input {
   color: #141823;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
   font-family:
     system,
     -apple-system,
@@ -19,6 +16,16 @@
     arial,
     sans-serif;
   font-size: 14px;
+}
+
+.graphiql-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
   height: 100%;
   margin: 0;
   overflow: hidden;
@@ -26,15 +33,17 @@
 }
 
 .graphiql-container .editorWrap {
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
-  display: -ms-flexbox;
-  -webkit-flex-direction: column;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
-  -webkit-flex: 1;
+  -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
+  overflow-x: hidden;
 }
 
 .graphiql-container .title {
@@ -47,53 +56,72 @@
 }
 
 .graphiql-container .topBarWrap {
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
-  -webkit-flex-direction: row;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
       -ms-flex-direction: row;
           flex-direction: row;
 }
 
 .graphiql-container .topBar {
-  -webkit-align-items: center;
-      -ms-align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
           align-items: center;
-  background: -webkit-linear-gradient(#f7f7f7, #e2e2e2);
-  background:         linear-gradient(#f7f7f7, #e2e2e2);
+  background: -webkit-gradient(linear, left top, left bottom, from(#f7f7f7), to(#e2e2e2));
+  background: linear-gradient(#f7f7f7, #e2e2e2);
   border-bottom: 1px solid #d0d0d0;
   cursor: default;
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
-  height: 34px;
-  padding: 7px 14px 6px;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: row;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
       -ms-flex-direction: row;
           flex-direction: row;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  height: 34px;
+  overflow-y: visible;
+  padding: 7px 14px 6px;
   -webkit-user-select: none;
+     -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
 }
 
 .graphiql-container .toolbar {
-  overflow-x: auto;
+  overflow-x: visible;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.graphiql-container .docExplorerShow {
-  background: -webkit-linear-gradient(#f7f7f7, #e2e2e2);
-  background:         linear-gradient(#f7f7f7, #e2e2e2);
+.graphiql-container .docExplorerShow,
+.graphiql-container .historyShow {
+  background: -webkit-gradient(linear, left top, left bottom, from(#f7f7f7), to(#e2e2e2));
+  background: linear-gradient(#f7f7f7, #e2e2e2);
+  border-radius: 0;
   border-bottom: 1px solid #d0d0d0;
-  border-left: 1px solid rgba(0, 0, 0, 0.2);
   border-right: none;
   border-top: none;
   color: #3B5998;
   cursor: pointer;
   font-size: 14px;
-  outline: 0;
   margin: 0;
+  outline: 0;
   padding: 2px 20px 0 18px;
+}
+
+.graphiql-container .docExplorerShow {
+  border-left: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.graphiql-container .historyShow {
+  border-right: 1px solid rgba(0, 0, 0, 0.2);
+  border-left: 0;
 }
 
 .graphiql-container .docExplorerShow:before {
@@ -105,51 +133,63 @@
   margin: 0 3px -1px 0;
   position: relative;
   -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
           transform: rotate(-45deg);
   width: 9px;
 }
 
 .graphiql-container .editorBar {
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: row;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
       -ms-flex-direction: row;
           flex-direction: row;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 
 .graphiql-container .queryWrap {
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: column;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 
 .graphiql-container .resultWrap {
   border-left: solid 1px #e0e0e0;
-  display: -webkit-flex;
-  display:         flex;
-  position: relative;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: column;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  position: relative;
 }
 
-.graphiql-container .docExplorerWrap {
+.graphiql-container .docExplorerWrap,
+.graphiql-container .historyPaneWrap {
   background: white;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
   position: relative;
   z-index: 3;
+}
+
+.graphiql-container .historyPaneWrap {
+  min-width: 230px;
+  z-index: 5;
 }
 
 .graphiql-container .docExplorerResizer {
@@ -169,21 +209,22 @@
   padding: 18px 16px 15px 12px;
 }
 
-.graphiql-container .query-editor {
-  -webkit-flex: 1;
+.graphiql-container div .query-editor {
+  -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
   position: relative;
 }
 
 .graphiql-container .variable-editor {
-  display: -webkit-flex;
-  display:     -ms-flex;
-  display:         flex;
-  height: 29px;
-  -webkit-flex-direction: column;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
+  height: 29px;
   position: relative;
 }
 
@@ -199,24 +240,25 @@
   padding: 6px 0 8px 43px;
   text-transform: lowercase;
   -webkit-user-select: none;
+     -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
 }
 
 .graphiql-container .codemirrorWrap {
-  -webkit-flex: 1;
+  -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  position: relative;
   height: 100%;
+  position: relative;
 }
 
 .graphiql-container .result-window {
-  -webkit-flex: 1;
+  -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  position: relative;
   height: 100%;
+  position: relative;
 }
 
 .graphiql-container .footer {
@@ -237,7 +279,8 @@
   width: 12px;
 }
 
-.graphiql-container .result-window .CodeMirror {
+/* No `.graphiql-container` here so themes can overwrite */
+.result-window .CodeMirror {
   background: #f6f7f8;
 }
 
@@ -255,49 +298,82 @@
 
 .graphiql-container .toolbar-button {
   background: #fdfdfd;
-  background: -webkit-linear-gradient(#fbfbfb, #f8f8f8);
-  background:         linear-gradient(#fbfbfb, #f8f8f8);
-  border-width: 0.5px;
-  border-style: solid;
-  border-color: #d3d3d3 #d0d0d0 #bababa;
-  border-radius: 4px;
-  box-shadow: 0 1px 1px -1px rgba(0, 0, 0, 0.13), inset 0 1px #fff;
-  color: #444;
+  background: -webkit-gradient(linear, left top, left bottom, from(#f9f9f9), to(#ececec));
+  background: linear-gradient(#f9f9f9, #ececec);
+  border-radius: 3px;
+  -webkit-box-shadow:
+    inset 0 0 0 1px rgba(0,0,0,0.20),
+    0 1px 0 rgba(255,255,255, 0.7),
+    inset 0 1px #fff;
+          box-shadow:
+    inset 0 0 0 1px rgba(0,0,0,0.20),
+    0 1px 0 rgba(255,255,255, 0.7),
+    inset 0 1px #fff;
+  color: #555;
   cursor: pointer;
   display: inline-block;
-  margin: 0 5px 0;
-  padding: 2px 8px 4px;
+  margin: 0 5px;
+  padding: 3px 11px 5px;
   text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 150px;
 }
 
 .graphiql-container .toolbar-button:active {
-  background: -webkit-linear-gradient(#ececec, #d8d8d8);
-  background:         linear-gradient(#ececec, #d8d8d8);
-  border-color: #cacaca #c9c9c9 #b0b0b0;
-  box-shadow:
-    0 1px 0 #fff,
-    inset 0 1px rgba(255, 255, 255, 0.2),
-    inset 0 1px 1px rgba(0, 0, 0, 0.08);
+  background: -webkit-gradient(linear, left top, left bottom, from(#ececec), to(#d5d5d5));
+  background: linear-gradient(#ececec, #d5d5d5);
+  -webkit-box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7),
+    inset 0 0 0 1px rgba(0,0,0,0.10),
+    inset 0 1px 1px 1px rgba(0, 0, 0, 0.12),
+    inset 0 0 5px rgba(0, 0, 0, 0.1);
+          box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7),
+    inset 0 0 0 1px rgba(0,0,0,0.10),
+    inset 0 1px 1px 1px rgba(0, 0, 0, 0.12),
+    inset 0 0 5px rgba(0, 0, 0, 0.1);
 }
 
 .graphiql-container .toolbar-button.error {
-  background: -webkit-linear-gradient(#fdf3f3, #e6d6d7);
-  background:         linear-gradient(#fdf3f3, #e6d6d7);
+  background: -webkit-gradient(linear, left top, left bottom, from(#fdf3f3), to(#e6d6d7));
+  background: linear-gradient(#fdf3f3, #e6d6d7);
   color: #b00;
 }
 
+.graphiql-container .toolbar-button-group {
+  margin: 0 5px;
+  white-space: nowrap;
+}
+
+.graphiql-container .toolbar-button-group > * {
+  margin: 0;
+}
+
+.graphiql-container .toolbar-button-group > *:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.graphiql-container .toolbar-button-group > *:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -1px;
+}
+
 .graphiql-container .execute-button-wrap {
-  position: relative;
-  margin: 0 14px 0 28px;
   height: 34px;
+  margin: 0 14px 0 28px;
+  position: relative;
 }
 
 .graphiql-container .execute-button {
-  background: -webkit-linear-gradient(#fdfdfd, #d2d3d6);
-  background:         linear-gradient(#fdfdfd, #d2d3d6);
-  border: 1px solid rgba(0,0,0,0.25);
+  background: -webkit-gradient(linear, left top, left bottom, from(#fdfdfd), to(#d2d3d6));
+  background: linear-gradient(#fdfdfd, #d2d3d6);
   border-radius: 17px;
-  box-shadow: 0 1px 0 #fff;
+  border: 1px solid rgba(0,0,0,0.25);
+  -webkit-box-shadow: 0 1px 0 #fff;
+          box-shadow: 0 1px 0 #fff;
   cursor: pointer;
   fill: #444;
   height: 34px;
@@ -311,46 +387,114 @@
 }
 
 .graphiql-container .execute-button:active {
-  background: -webkit-linear-gradient(#e6e6e6, #c0c0c0);
-  background:         linear-gradient(#e6e6e6, #c0c0c0);
-  box-shadow:
+  background: -webkit-gradient(linear, left top, left bottom, from(#e6e6e6), to(#c3c3c3));
+  background: linear-gradient(#e6e6e6, #c3c3c3);
+  -webkit-box-shadow:
     0 1px 0 #fff,
-    inset 0 0 2px rgba(0, 0, 0, 0.3),
-    inset 0 0 6px rgba(0, 0, 0, 0.2);
+    inset 0 0 2px rgba(0, 0, 0, 0.2),
+    inset 0 0 6px rgba(0, 0, 0, 0.1);
+          box-shadow:
+    0 1px 0 #fff,
+    inset 0 0 2px rgba(0, 0, 0, 0.2),
+    inset 0 0 6px rgba(0, 0, 0, 0.1);
 }
 
 .graphiql-container .execute-button:focus {
   outline: 0;
 }
 
-.graphiql-container .execute-options {
+.graphiql-container .toolbar-menu,
+.graphiql-container .toolbar-select {
+  position: relative;
+}
+
+.graphiql-container .execute-options,
+.graphiql-container .toolbar-menu-items,
+.graphiql-container .toolbar-select-options {
   background: #fff;
-  box-shadow:
+  -webkit-box-shadow:
     0 0 0 1px rgba(0,0,0,0.1),
     0 2px 4px rgba(0,0,0,0.25);
-  left: -1px;
+          box-shadow:
+    0 0 0 1px rgba(0,0,0,0.1),
+    0 2px 4px rgba(0,0,0,0.25);
   margin: 0;
-  padding: 8px 0;
+  padding: 6px 0;
   position: absolute;
-  top: 37px;
   z-index: 100;
 }
 
-.graphiql-container .execute-options li {
-  padding: 2px 30px 4px 10px;
-  list-style: none;
+.graphiql-container .execute-options {
   min-width: 100px;
-  cursor: pointer;
+  top: 37px;
+  left: -1px;
 }
 
-.graphiql-container .execute-options li.selected {
+.graphiql-container .toolbar-menu-items {
+  left: 1px;
+  margin-top: -1px;
+  min-width: 110%;
+  top: 100%;
+  visibility: hidden;
+}
+
+.graphiql-container .toolbar-menu-items.open {
+  visibility: visible;
+}
+
+.graphiql-container .toolbar-select-options {
+  left: 0;
+  min-width: 100%;
+  top: -5px;
+  visibility: hidden;
+}
+
+.graphiql-container .toolbar-select-options.open {
+  visibility: visible;
+}
+
+.graphiql-container .execute-options > li,
+.graphiql-container .toolbar-menu-items > li,
+.graphiql-container .toolbar-select-options > li {
+  cursor: pointer;
+  display: block;
+  margin: none;
+  max-width: 300px;
+  overflow: hidden;
+  padding: 2px 20px 4px 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graphiql-container .execute-options > li.selected,
+.graphiql-container .toolbar-menu-items > li.hover,
+.graphiql-container .toolbar-menu-items > li:active,
+.graphiql-container .toolbar-menu-items > li:hover,
+.graphiql-container .toolbar-select-options > li.hover,
+.graphiql-container .toolbar-select-options > li:active,
+.graphiql-container .toolbar-select-options > li:hover,
+.graphiql-container .history-contents > p:hover,
+.graphiql-container .history-contents > p:active {
   background: #e10098;
-  color: white;
+  color: #fff;
+}
+
+.graphiql-container .toolbar-select-options > li > svg {
+  display: inline;
+  fill: #666;
+  margin: 0 -6px 0 6px;
+  pointer-events: none;
+  vertical-align: middle;
+}
+
+.graphiql-container .toolbar-select-options > li.hover > svg,
+.graphiql-container .toolbar-select-options > li:active > svg,
+.graphiql-container .toolbar-select-options > li:hover > svg {
+  fill: #fff;
 }
 
 .graphiql-container .CodeMirror-scroll {
-  -webkit-overflow-scrolling: touch;
-      -ms-overflow-scrolling: touch;
+  overflow-scrolling: touch;
 }
 
 .graphiql-container .CodeMirror {
@@ -374,15 +518,14 @@
 }
 
 .CodeMirror-hint-information .content {
-  -webkit-box-orient: vertical;
-      -ms-box-orient: vertical;
-          box-orient: vertical;
+  box-orient: vertical;
   color: #141823;
   display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-family: system, -apple-system, 'San Francisco', '.SFNSDisplay-Regular', 'Segoe UI', Segoe, 'Segoe WP', 'Helvetica Neue', helvetica, 'Lucida Grande', arial, sans-serif;
   font-size: 13px;
-  -webkit-line-clamp: 3;
-          line-clamp: 3;
+  line-clamp: 3;
   line-height: 16px;
   max-height: 48px;
   overflow: hidden;
@@ -398,7 +541,7 @@
 }
 
 .CodeMirror-hint-information .infoType {
-  color: #30a;
+  color: #CA9800;
   cursor: pointer;
   display: inline;
   margin-right: 0.5em;
@@ -406,29 +549,13 @@
 
 .autoInsertedLeaf.cm-property {
   -webkit-animation-duration: 6s;
-     -moz-animation-duration: 6s;
-      -ms-animation-duration: 6s;
           animation-duration: 6s;
   -webkit-animation-name: insertionFade;
-     -moz-animation-name: insertionFade;
-      -ms-animation-name: insertionFade;
           animation-name: insertionFade;
   border-bottom: 2px solid rgba(255, 255, 255, 0);
   border-radius: 2px;
   margin: -2px -4px -1px;
   padding: 2px 4px 1px;
-}
-
-@-moz-keyframes insertionFade {
-  from, to {
-    background: rgba(255, 255, 255, 0);
-    border-color: rgba(255, 255, 255, 0);
-  }
-
-  15%, 85% {
-    background: #fbffc9;
-    border-color: #f0f3c0;
-  }
 }
 
 @-webkit-keyframes insertionFade {
@@ -457,10 +584,11 @@
 
 div.CodeMirror-lint-tooltip {
   background-color: white;
-  border: 0;
   border-radius: 2px;
+  border: 0;
   color: #141823;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   font-family:
     system,
     -apple-system,
@@ -476,17 +604,20 @@ div.CodeMirror-lint-tooltip {
     sans-serif;
   font-size: 13px;
   line-height: 16px;
+  max-width: 430px;
   opacity: 0;
-  padding: 6px 10px;
+  padding: 8px 10px;
   -webkit-transition: opacity 0.15s;
-     -moz-transition: opacity 0.15s;
-      -ms-transition: opacity 0.15s;
-       -o-transition: opacity 0.15s;
-          transition: opacity 0.15s;
+  transition: opacity 0.15s;
+  white-space: pre-wrap;
 }
 
-div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
+div.CodeMirror-lint-tooltip > * {
   padding-left: 23px;
+}
+
+div.CodeMirror-lint-tooltip > * + * {
+  margin-top: 12px;
 }
 
 /* COLORS */
@@ -494,11 +625,12 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
 .graphiql-container .CodeMirror-foldmarker {
   border-radius: 4px;
   background: #08f;
-  background: -webkit-linear-gradient(#43A8FF, #0F83E8);
-  background:    -moz-linear-gradient(#43A8FF, #0F83E8);
-  background:     -ms-linear-gradient(#43A8FF, #0F83E8);
-  background:         linear-gradient(#43A8FF, #0F83E8);
-  box-shadow:
+  background: -webkit-gradient(linear, left top, left bottom, from(#43A8FF), to(#0F83E8));
+  background: linear-gradient(#43A8FF, #0F83E8);
+  -webkit-box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.2),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+          box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.2),
     inset 0 0 0 1px rgba(0, 0, 0, 0.1);
   color: white;
@@ -592,9 +724,9 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
 
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
+  color: black;
   font-family: monospace;
   height: 300px;
-  color: black;
 }
 
 /* PADDING */
@@ -619,10 +751,10 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
 }
 .CodeMirror-linenumbers {}
 .CodeMirror-linenumber {
-  padding: 0 3px 0 5px;
-  min-width: 20px;
-  text-align: right;
   color: #999;
+  min-width: 20px;
+  padding: 0 3px 0 5px;
+  text-align: right;
   white-space: nowrap;
 }
 
@@ -631,7 +763,7 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
 
 /* CURSOR */
 
-.CodeMirror div.CodeMirror-cursor {
+.CodeMirror .CodeMirror-cursor {
   border-left: 1px solid black;
 }
 /* Shown when moving in bi-directional text */
@@ -639,26 +771,19 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
   border-left: 1px solid silver;
 }
 .CodeMirror.cm-fat-cursor div.CodeMirror-cursor {
-  width: auto;
-  border: 0;
   background: #7e7;
+  border: 0;
+  width: auto;
 }
 .CodeMirror.cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
 
 .cm-animate-fat-cursor {
-  width: auto;
-  border: 0;
   -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  -ms-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-}
-@-moz-keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
+          animation: blink 1.06s steps(1) infinite;
+  border: 0;
+  width: auto;
 }
 @-webkit-keyframes blink {
   0% { background: #7e7; }
@@ -732,43 +857,43 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
    the editor. You probably shouldn't touch them. */
 
 .CodeMirror {
-  position: relative;
-  overflow: hidden;
   background: white;
+  overflow: hidden;
+  position: relative;
 }
 
 .CodeMirror-scroll {
-  overflow: scroll !important; /* Things will break if this is overridden */
+  height: 100%;
   /* 30px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
   margin-bottom: -30px; margin-right: -30px;
-  padding-bottom: 30px;
-  height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
+  overflow: scroll !important; /* Things will break if this is overridden */
+  padding-bottom: 30px;
   position: relative;
 }
 .CodeMirror-sizer {
-  position: relative;
   border-right: 30px solid transparent;
+  position: relative;
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
    before actual scrolling happens, thus preventing shaking and
    flickering artifacts. */
 .CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  display: none;
   position: absolute;
   z-index: 6;
-  display: none;
 }
 .CodeMirror-vscrollbar {
-  right: 0; top: 0;
   overflow-x: hidden;
   overflow-y: scroll;
+  right: 0; top: 0;
 }
 .CodeMirror-hscrollbar {
   bottom: 0; left: 0;
-  overflow-y: hidden;
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 .CodeMirror-scrollbar-filler {
   right: 0; bottom: 0;
@@ -778,25 +903,25 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-gutters {
-  position: absolute; left: 0; top: 0;
   min-height: 100%;
+  position: absolute; left: 0; top: 0;
   z-index: 3;
 }
 .CodeMirror-gutter {
-  white-space: normal;
-  height: 100%;
   display: inline-block;
-  vertical-align: top;
+  height: 100%;
   margin-bottom: -30px;
+  vertical-align: top;
+  white-space: normal;
   /* Hack to make IE7 behave */
   *zoom:1;
   *display:inline;
 }
 .CodeMirror-gutter-wrapper {
-  position: absolute;
-  z-index: 4;
   background: none !important;
   border: none !important;
+  position: absolute;
+  z-index: 4;
 }
 .CodeMirror-gutter-background {
   position: absolute;
@@ -804,15 +929,15 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   z-index: 4;
 }
 .CodeMirror-gutter-elt {
-  position: absolute;
   cursor: default;
+  position: absolute;
   z-index: 4;
 }
 .CodeMirror-gutter-wrapper {
   -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 
 .CodeMirror-lines {
@@ -820,23 +945,23 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   min-height: 1px; /* prevents collapsing before first draw */
 }
 .CodeMirror pre {
+  -webkit-tap-highlight-color: transparent;
   /* Reset some styles that the rest of the page might have set */
-  -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
-  border-width: 0;
   background: transparent;
+  border-radius: 0;
+  border-width: 0;
+  color: inherit;
   font-family: inherit;
   font-size: inherit;
+  -webkit-font-variant-ligatures: none;
+          font-variant-ligatures: none;
+  line-height: inherit;
   margin: 0;
+  overflow: visible;
+  position: relative;
   white-space: pre;
   word-wrap: normal;
-  line-height: inherit;
-  color: inherit;
   z-index: 2;
-  position: relative;
-  overflow: visible;
-  -webkit-tap-highlight-color: transparent;
-  -webkit-font-variant-ligatures: none;
-  font-variant-ligatures: none;
 }
 .CodeMirror-wrap pre {
   word-wrap: break-word;
@@ -851,9 +976,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-linewidget {
+  overflow: auto;
   position: relative;
   z-index: 2;
-  overflow: auto;
 }
 
 .CodeMirror-widget {}
@@ -868,24 +993,24 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-gutter,
 .CodeMirror-gutters,
 .CodeMirror-linenumber {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+          box-sizing: content-box;
 }
 
 .CodeMirror-measure {
-  position: absolute;
-  width: 100%;
   height: 0;
   overflow: hidden;
+  position: absolute;
   visibility: hidden;
+  width: 100%;
 }
 
 .CodeMirror-cursor { position: absolute; }
 .CodeMirror-measure pre { position: static; }
 
 div.CodeMirror-cursors {
-  visibility: hidden;
   position: relative;
+  visibility: hidden;
   z-index: 3;
 }
 div.CodeMirror-dragcursors {
@@ -899,6 +1024,7 @@ div.CodeMirror-dragcursors {
 .CodeMirror-selected { background: #d9d9d9; }
 .CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
 .CodeMirror-crosshair { cursor: crosshair; }
+.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
 .CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }
 .CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
 
@@ -927,13 +1053,13 @@ div.CodeMirror-dragcursors {
 span.CodeMirror-selectedtext { background: none; }
 
 .CodeMirror-dialog {
-  position: absolute;
-  left: 0; right: 0;
   background: inherit;
-  z-index: 15;
-  padding: .1em .8em;
-  overflow: hidden;
   color: inherit;
+  left: 0; right: 0;
+  overflow: hidden;
+  padding: .1em .8em;
+  position: absolute;
+  z-index: 15;
 }
 
 .CodeMirror-dialog-top {
@@ -947,12 +1073,12 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .CodeMirror-dialog input {
-  border: 1px solid #d3d6db;
-  outline: none;
   background: transparent;
-  width: 20em;
+  border: 1px solid #d3d6db;
   color: inherit;
   font-family: monospace;
+  outline: none;
+  width: 20em;
 }
 
 .CodeMirror-dialog button {
@@ -962,9 +1088,10 @@ span.CodeMirror-selectedtext { background: none; }
   background: white;
 }
 
-.graphiql-container .doc-explorer-title-bar {
+.graphiql-container .doc-explorer-title-bar,
+.graphiql-container .history-title-bar {
   cursor: default;
-  display: -webkit-flex;
+  display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   height: 34px;
@@ -972,19 +1099,26 @@ span.CodeMirror-selectedtext { background: none; }
   padding: 8px 8px 5px;
   position: relative;
   -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
           user-select: none;
 }
 
-.graphiql-container .doc-explorer-title {
-  padding: 10px 0 10px 10px;
-  font-weight: bold;
-  text-align: center;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-x: hidden;
-  -webkit-flex: 1;
+.graphiql-container .doc-explorer-title,
+.graphiql-container .history-title {
+  -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
+  font-weight: bold;
+  overflow-x: hidden;
+  padding: 10px 0 10px 10px;
+  text-align: center;
+  text-overflow: ellipsis;
+  -webkit-user-select: initial;
+     -moz-user-select: initial;
+      -ms-user-select: initial;
+          user-select: initial;
+  white-space: nowrap;
 }
 
 .graphiql-container .doc-explorer-back {
@@ -997,6 +1131,10 @@ span.CodeMirror-selectedtext { background: none; }
   white-space: nowrap;
 }
 
+.doc-explorer-narrow .doc-explorer-back {
+  width: 0;
+}
+
 .graphiql-container .doc-explorer-back:before {
   border-left: 2px solid #3B5998;
   border-top: 2px solid #3B5998;
@@ -1005,27 +1143,30 @@ span.CodeMirror-selectedtext { background: none; }
   height: 9px;
   margin: 0 3px -1px 0;
   position: relative;
-  width: 9px;
   -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
           transform: rotate(-45deg);
+  width: 9px;
 }
 
 .graphiql-container .doc-explorer-rhs {
   position: relative;
 }
 
-.graphiql-container .doc-explorer-contents {
+.graphiql-container .doc-explorer-contents,
+.graphiql-container .history-contents {
   background-color: #ffffff;
   border-top: 1px solid #d6d6d6;
   bottom: 0;
   left: 0;
-  min-width: 300px;
   overflow-y: auto;
   padding: 20px 15px;
   position: absolute;
   right: 0;
   top: 47px;
+}
+
+.graphiql-container .doc-explorer-contents {
+  min-width: 300px;
 }
 
 .graphiql-container .doc-type-description p:first-child ,
@@ -1042,8 +1183,12 @@ span.CodeMirror-selectedtext { background: none; }
   text-decoration: underline;
 }
 
-.graphiql-container .doc-value-description {
-  padding: 4px 0 8px 12px;
+.graphiql-container .doc-value-description > :first-child {
+  margin-top: 4px;
+}
+
+.graphiql-container .doc-value-description > :last-child {
+  margin-bottom: 4px;
 }
 
 .graphiql-container .doc-category {
@@ -1061,6 +1206,7 @@ span.CodeMirror-selectedtext { background: none; }
   margin: 0 -15px 10px 0;
   padding: 10px 0;
   -webkit-user-select: none;
+     -moz-user-select: none;
       -ms-user-select: none;
           user-select: none;
 }
@@ -1082,7 +1228,14 @@ span.CodeMirror-selectedtext { background: none; }
   color: #1F61A0;
 }
 
-.graphiql-container .value-name {
+.graphiql-container .field-short-description {
+  color: #999;
+  margin-left: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.graphiql-container .enum-value {
   color: #0B7FC7;
 }
 
@@ -1090,46 +1243,151 @@ span.CodeMirror-selectedtext { background: none; }
   color: #8B2BB9;
 }
 
-.graphiql-container .arg:after {
+.graphiql-container .arg {
+  display: block;
+  margin-left: 1em;
+}
+
+.graphiql-container .arg:first-child:last-child,
+.graphiql-container .arg:first-child:nth-last-child(2),
+.graphiql-container .arg:first-child:nth-last-child(2) ~ .arg {
+  display: inherit;
+  margin: inherit;
+}
+
+.graphiql-container .arg:first-child:nth-last-child(2):after {
   content: ', ';
 }
 
-.graphiql-container .arg:last-child:after {
-  content: '';
+.graphiql-container .arg-default-value {
+  color: #43A047;
 }
 
-.graphiql-container .doc-alert-text {
-  color: #F00F00;
-  font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
-  font-size: 13px;
+.graphiql-container .doc-deprecation {
+  background: #fffae8;
+  -webkit-box-shadow: inset 0 0 1px #bfb063;
+          box-shadow: inset 0 0 1px #bfb063;
+  color: #867F70;
+  line-height: 16px;
+  margin: 8px -8px;
+  max-height: 80px;
+  overflow: hidden;
+  padding: 8px;
+  border-radius: 3px;
 }
 
-.graphiql-container .search-box-outer {
-  border: 1px solid #d3d6db;
-  box-sizing: border-box;
-  display: inline-block;
-  font-size: 12px;
-  height: 24px;
-  margin-bottom: 12px;
-  padding: 3px 8px 5px;
-  vertical-align: middle;
+.graphiql-container .doc-deprecation:before {
+  content: 'Deprecated:';
+  color: #c79b2e;
+  cursor: default;
+  display: block;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.graphiql-container .doc-deprecation > :first-child {
+  margin-top: 0;
+}
+
+.graphiql-container .doc-deprecation > :last-child {
+  margin-bottom: 0;
+}
+
+.graphiql-container .show-btn {
+  -webkit-appearance: initial;
+  display: block;
+  border-radius: 3px;
+  border: solid 1px #ccc;
+  text-align: center;
+  padding: 8px 12px 10px;
+  width: 100%;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  background: #fbfcfc;
+  color: #555;
+  cursor: pointer;
+}
+
+.graphiql-container .search-box {
+  border-bottom: 1px solid #d3d6db;
+  display: block;
+  font-size: 14px;
+  margin: -15px -15px 12px 0;
+  position: relative;
+}
+
+.graphiql-container .search-box:before {
+  content: '\26b2';
+  cursor: pointer;
+  display: block;
+  font-size: 24px;
+  position: absolute;
+  top: -2px;
+  -webkit-transform: rotate(-45deg);
+          transform: rotate(-45deg);
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.graphiql-container .search-box .search-box-clear {
+  background-color: #d0d0d0;
+  border-radius: 12px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 1px 5px 2px;
+  position: absolute;
+  right: 3px;
+  top: 8px;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.graphiql-container .search-box .search-box-clear:hover {
+  background-color: #b9b9b9;
+}
+
+.graphiql-container .search-box > input {
+  border: none;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  font-size: 14px;
+  outline: none;
+  padding: 6px 24px 8px 20px;
   width: 100%;
 }
 
-.graphiql-container .search-box-input {
-  border: 0;
-  font-size: 12px;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-  width: 100%;
+.graphiql-container .error-container {
+  font-weight: bold;
+  left: 0;
+  letter-spacing: 1px;
+  opacity: 0.5;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  text-transform: uppercase;
+  top: 50%;
+  -webkit-transform: translate(0, -50%);
+          transform: translate(0, -50%);
 }
 .CodeMirror-foldmarker {
   color: blue;
-  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  cursor: pointer;
   font-family: arial;
   line-height: .3;
-  cursor: pointer;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
 }
 .CodeMirror-foldgutter {
   width: .7em;
@@ -1144,6 +1402,142 @@ span.CodeMirror-selectedtext { background: none; }
 .CodeMirror-foldgutter-folded:after {
   content: "\25B8";
 }
+.graphiql-container .history-contents {
+  font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
+  padding: 0;
+}
+
+.graphiql-container .history-contents p {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0;
+  padding: 8px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.graphiql-container .history-contents p:hover {
+  cursor: pointer;
+}
+.CodeMirror-info {
+  background: white;
+  border-radius: 2px;
+  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  color: #555;
+  font-family:
+    system,
+    -apple-system,
+    'San Francisco',
+    '.SFNSDisplay-Regular',
+    'Segoe UI',
+    Segoe,
+    'Segoe WP',
+    'Helvetica Neue',
+    helvetica,
+    'Lucida Grande',
+    arial,
+    sans-serif;
+  font-size: 13px;
+  line-height: 16px;
+  margin: 8px -8px;
+  max-width: 400px;
+  opacity: 0;
+  overflow: hidden;
+  padding: 8px 8px;
+  position: fixed;
+  -webkit-transition: opacity 0.15s;
+  transition: opacity 0.15s;
+  z-index: 50;
+}
+
+.CodeMirror-info :first-child {
+  margin-top: 0;
+}
+
+.CodeMirror-info :last-child {
+  margin-bottom: 0;
+}
+
+.CodeMirror-info p {
+  margin: 1em 0;
+}
+
+.CodeMirror-info .info-description {
+  color: #777;
+  line-height: 16px;
+  margin-top: 1em;
+  max-height: 80px;
+  overflow: hidden;
+}
+
+.CodeMirror-info .info-deprecation {
+  background: #fffae8;
+  -webkit-box-shadow: inset 0 1px 1px -1px #bfb063;
+          box-shadow: inset 0 1px 1px -1px #bfb063;
+  color: #867F70;
+  line-height: 16px;
+  margin: -8px;
+  margin-top: 8px;
+  max-height: 80px;
+  overflow: hidden;
+  padding: 8px;
+}
+
+.CodeMirror-info .info-deprecation-label {
+  color: #c79b2e;
+  cursor: default;
+  display: block;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.CodeMirror-info .info-deprecation-label + * {
+  margin-top: 0;
+}
+
+.CodeMirror-info a {
+  text-decoration: none;
+}
+
+.CodeMirror-info a:hover {
+  text-decoration: underline;
+}
+
+.CodeMirror-info .type-name {
+  color: #CA9800;
+}
+
+.CodeMirror-info .field-name {
+  color: #1F61A0;
+}
+
+.CodeMirror-info .enum-value {
+  color: #0B7FC7;
+}
+
+.CodeMirror-info .arg-name {
+  color: #8B2BB9;
+}
+
+.CodeMirror-info .directive-name {
+  color: #B33086;
+}
+.CodeMirror-jump-token {
+  text-decoration: underline;
+  cursor: pointer;
+}
 /* The lint marker gutter */
 .CodeMirror-lint-markers {
   width: 16px;
@@ -1151,24 +1545,20 @@ span.CodeMirror-selectedtext { background: none; }
 
 .CodeMirror-lint-tooltip {
   background-color: infobackground;
-  border: 1px solid black;
   border-radius: 4px 4px 4px 4px;
+  border: 1px solid black;
   color: infotext;
   font-family: monospace;
   font-size: 10pt;
+  max-width: 600px;
+  opacity: 0;
   overflow: hidden;
   padding: 2px 5px;
   position: fixed;
-  white-space: pre;
+  -webkit-transition: opacity .4s;
+  transition: opacity .4s;
   white-space: pre-wrap;
   z-index: 100;
-  max-width: 600px;
-  opacity: 0;
-  transition: opacity .4s;
-  -moz-transition: opacity .4s;
-  -webkit-transition: opacity .4s;
-  -o-transition: opacity .4s;
-  -ms-transition: opacity .4s;
 }
 
 .CodeMirror-lint-mark-error, .CodeMirror-lint-mark-warning {
@@ -1192,15 +1582,15 @@ span.CodeMirror-selectedtext { background: none; }
   cursor: pointer;
   display: inline-block;
   height: 16px;
-  width: 16px;
-  vertical-align: middle;
   position: relative;
+  vertical-align: middle;
+  width: 16px;
 }
 
 .CodeMirror-lint-message-error, .CodeMirror-lint-message-warning {
-  padding-left: 18px;
   background-position: top left;
   background-repeat: no-repeat;
+  padding-left: 18px;
 }
 
 .CodeMirror-lint-marker-error, .CodeMirror-lint-message-error {
@@ -1213,91 +1603,60 @@ span.CodeMirror-selectedtext { background: none; }
 
 .CodeMirror-lint-marker-multiple {
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAMAAADzjKfhAAAACVBMVEUAAAAAAAC/v7914kyHAAAAAXRSTlMAQObYZgAAACNJREFUeNo1ioEJAAAIwmz/H90iFFSGJgFMe3gaLZ0od+9/AQZ0ADosbYraAAAAAElFTkSuQmCC");
-  background-repeat: no-repeat;
   background-position: right bottom;
+  background-repeat: no-repeat;
   width: 100%; height: 100%;
 }
 .graphiql-container .spinner-container {
+  height: 36px;
+  left: 50%;
   position: absolute;
   top: 50%;
-  height: 36px;
+  -webkit-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
   width: 36px;
-  left: 50%;
-  transform: translate(-50%, -50%);
   z-index: 10;
 }
 
 .graphiql-container .spinner {
-  vertical-align: middle;
+  -webkit-animation: rotation .6s infinite linear;
+          animation: rotation .6s infinite linear;
+  border-bottom: 6px solid rgba(150, 150, 150, .15);
+  border-left: 6px solid rgba(150, 150, 150, .15);
+  border-radius: 100%;
+  border-right: 6px solid rgba(150, 150, 150, .15);
+  border-top: 6px solid rgba(150, 150, 150, .8);
   display: inline-block;
   height: 24px;
-  width: 24px;
   position: absolute;
-  -webkit-animation: rotation .6s infinite linear;
-  -moz-animation: rotation .6s infinite linear;
-  -o-animation: rotation .6s infinite linear;
-  animation: rotation .6s infinite linear;
-  border-left: 6px solid rgba(150, 150, 150, .15);
-  border-right: 6px solid rgba(150, 150, 150, .15);
-  border-bottom: 6px solid rgba(150, 150, 150, .15);
-  border-top: 6px solid rgba(150, 150, 150, .8);
-  border-radius: 100%;
+  vertical-align: middle;
+  width: 24px;
 }
 
 @-webkit-keyframes rotation {
-  from { -webkit-transform: rotate(0deg); }
-  to { -webkit-transform: rotate(359deg); }
-}
-
-@-moz-keyframes rotation {
-  from { -moz-transform: rotate(0deg); }
-  to { -moz-transform: rotate(359deg); }
-}
-
-@-o-keyframes rotation {
-  from { -o-transform: rotate(0deg); }
-  to { -o-transform: rotate(359deg); }
+  from { -webkit-transform: rotate(0deg); transform: rotate(0deg); }
+  to { -webkit-transform: rotate(359deg); transform: rotate(359deg); }
 }
 
 @keyframes rotation {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(359deg); }
+  from { -webkit-transform: rotate(0deg); transform: rotate(0deg); }
+  to { -webkit-transform: rotate(359deg); transform: rotate(359deg); }
 }
 .CodeMirror-hints {
   background: white;
   -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-     -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
   font-size: 13px;
   list-style: none;
-  margin: 0;
   margin-left: -6px;
+  margin: 0;
   max-height: 14.5em;
   overflow-y: auto;
   overflow: hidden;
   padding: 0;
   position: absolute;
   z-index: 10;
-}
-
-.CodeMirror-hints-wrapper {
-  background: white;
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-     -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-  margin-left: -6px;
-  position: absolute;
-  z-index: 10;
-}
-
-.CodeMirror-hints-wrapper .CodeMirror-hints {
-  -webkit-box-shadow: none;
-   -moz-box-shadow: none;
-        box-shadow: none;
-  position: relative;
-  margin-left: 0;
-  z-index: 0;
 }
 
 .CodeMirror-hint {
@@ -1329,4 +1688,54 @@ li.CodeMirror-hint-active {
   border-bottom: solid 1px #c0c0c0;
   border-top: none;
   margin-bottom: -1px;
+}
+
+.CodeMirror-hint-deprecation {
+  background: #fffae8;
+  -webkit-box-shadow: inset 0 1px 1px -1px #bfb063;
+          box-shadow: inset 0 1px 1px -1px #bfb063;
+  color: #867F70;
+  font-family:
+    system,
+    -apple-system,
+    'San Francisco',
+    '.SFNSDisplay-Regular',
+    'Segoe UI',
+    Segoe,
+    'Segoe WP',
+    'Helvetica Neue',
+    helvetica,
+    'Lucida Grande',
+    arial,
+    sans-serif;
+  font-size: 13px;
+  line-height: 16px;
+  margin-top: 4px;
+  max-height: 80px;
+  overflow: hidden;
+  padding: 6px;
+}
+
+.CodeMirror-hint-deprecation .deprecation-label {
+  color: #c79b2e;
+  cursor: default;
+  display: block;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+
+.CodeMirror-hint-deprecation .deprecation-label + * {
+  margin-top: 0;
+}
+
+.CodeMirror-hint-deprecation :last-child {
+  margin-bottom: 0;
 }

--- a/src/devtools/style.less
+++ b/src/devtools/style.less
@@ -62,7 +62,6 @@ h3 {
     bottom: 0;
     top: 0;
     right: 0;
-    z-index: 100;
     background-color: white;
   }
 


### PR DESCRIPTION
Fixes #66.

This PR updates the vendored graphiql styles to match what is in graphiql 0.11.11's dist.

This PR also removes an unnecessary (as far as I can tell) z-index override that was causing all the code hints in the editor (including autocomplete) to not be displayed correctly.

Here's a GIF with the new CSS in action:

![autocomplete](https://user-images.githubusercontent.com/1151810/40265189-9eaa401c-5b01-11e8-9f65-fef52980de88.gif)