### PR TITLE
Fixed issue when query.queryString doesn't exist anymore

### DIFF
--- a/src/devtools/components/Mutations/Mutations.js
+++ b/src/devtools/components/Mutations/Mutations.js
@@ -12,7 +12,9 @@ import Warning from "../Images/Warning";
 import "../WatchedQueries/WatchedQueries.less";
 
 const mutationLabel = (mutationId, mutation) => {
-  const mutationName = getOperationName(parse(mutation.mutationString));
+  const mutationName = getOperationName(
+    parse(mutation.mutationString || mutation.document.loc.source.body),
+  );
   if (mutationName === null) {
     return mutationId;
   }
@@ -180,6 +182,9 @@ class WatchedMutation extends React.Component {
       mutation.metadata &&
       mutation.metadata.reactComponent &&
       mutation.metadata.reactComponent.displayName;
+
+    const mutationString =
+      mutation.mutationString || mutation.document.loc.source.body;
     return (
       <div className={classnames("main", { loading: mutation.loading })}>
         <div className="panel-title">
@@ -191,7 +196,7 @@ class WatchedMutation extends React.Component {
             className="show-in-graphiql-link"
             onClick={() =>
               this.props.onRun(
-                mutation.mutationString,
+                mutationString,
                 mutation.variables,
                 "Mutations",
                 false,
@@ -214,7 +219,7 @@ class WatchedMutation extends React.Component {
         <LabeledShowHide label="Mutation string" show={false}>
           <GraphqlCodeBlock
             className="GraphqlCodeBlock"
-            queryBody={mutation.mutationString}
+            queryBody={mutationString}
           />
         </LabeledShowHide>
         {mutation.graphQLErrors &&

--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -12,7 +12,7 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
-  const queryName = getOperationName(parse(query.document.loc.source.body));
+  const queryName = getOperationName(parse(query.queryString || query.document.loc.source.body));
   if (queryName === null) {
     return queryId;
   }
@@ -179,6 +179,7 @@ class WatchedQuery extends React.Component {
       query.metadata &&
       query.metadata.reactComponent &&
       query.metadata.reactComponent.displayName;
+    const queryString = query.queryString || query.document.loc.source.body;
     return (
       <div className={classnames("main", { loading: query.loading })}>
         <div className="panel-title">
@@ -190,7 +191,7 @@ class WatchedQuery extends React.Component {
             className="run-in-graphiql-link"
             onClick={() =>
               this.props.onRun(
-                query.document.loc.source.body,
+                queryString,
                 query.variables,
                 "WatchedQueries",
                 true,
@@ -213,7 +214,7 @@ class WatchedQuery extends React.Component {
         <LabeledShowHide label="Query string" show={false}>
           <GraphqlCodeBlock
             className="GraphqlCodeBlock"
-            queryBody={query.document.loc.source.body}
+            queryBody={queryString}
           />
         </LabeledShowHide>
         {query.graphQLErrors &&

--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -12,7 +12,7 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
-  const queryName = getOperationName(parse(query.queryString));
+  const queryName = getOperationName(parse(query.document.loc.source.body));
   if (queryName === null) {
     return queryId;
   }
@@ -190,7 +190,7 @@ class WatchedQuery extends React.Component {
             className="run-in-graphiql-link"
             onClick={() =>
               this.props.onRun(
-                query.queryString,
+                query.document.loc.source.body,
                 query.variables,
                 "WatchedQueries",
                 true,
@@ -213,7 +213,7 @@ class WatchedQuery extends React.Component {
         <LabeledShowHide label="Query string" show={false}>
           <GraphqlCodeBlock
             className="GraphqlCodeBlock"
-            queryBody={query.queryString}
+            queryBody={query.document.loc.source.body}
           />
         </LabeledShowHide>
         {query.graphQLErrors &&


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
/label bug
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This fixes an issue encountered on react-apollo 2 which closes #119 