### PR TITLE
Change cursor in dark theme to white

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+* Change cursor in dark theme to white ([#131](https://github.com/apollographql/apollo-client-devtools/pull/131))
+
 ## 2.1.3
 
 * fixed styling of mutation list

--- a/src/devtools/components/Explorer/graphiql-overrides.less
+++ b/src/devtools/components/Explorer/graphiql-overrides.less
@@ -5,6 +5,9 @@
        color: white !important; 
       }
   }
+  .CodeMirror .CodeMirror-cursor {
+    border-left-color: white;
+  }
 }
 .graphiql-container {
   .CodeMirror pre {


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
In this PR we change cursor color to white in dark theme

| Before | After |
|-|-|
| ![41821523-4619e0bc-77e2-11e8-9afe-3c60015a0240](https://user-images.githubusercontent.com/7680511/42346200-2630491c-80a2-11e8-9214-635fc9519023.png) |  <img width="450" alt="screen shot 2018-07-05 at 22 21 36" src="https://user-images.githubusercontent.com/7680511/42346192-19fdf87e-80a2-11e8-987c-ea08585293cb.png"> |

fixes https://github.com/apollographql/apollo-client-devtools/issues/130