### PR TITLE
Fix issue where "Run in GraphiQL" does not including fragments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## vNext
 
 * Change cursor in dark theme to white ([#131](https://github.com/apollographql/apollo-client-devtools/pull/131))
+* Fix issue where "Run in GraphiQL" does not include fragments ([#133](https://github.com/apollographql/apollo-client-devtools/pull/133))
 
 ## 2.1.3
 

--- a/src/devtools/components/Mutations/Mutations.js
+++ b/src/devtools/components/Mutations/Mutations.js
@@ -5,6 +5,7 @@ import sortBy from "lodash.sortby";
 import classnames from "classnames";
 import { getOperationName } from "apollo-utilities";
 import { parse } from "graphql/language/parser";
+import { print } from "graphql/language/printer";
 import { GraphqlCodeBlock } from "graphql-syntax-highlighter-react";
 import { Sidebar } from "../Sidebar";
 import Warning from "../Images/Warning";
@@ -189,8 +190,7 @@ class WatchedMutation extends React.Component {
       mutation.metadata.component.displayName;
     const displayName = componentDisplayName || reactComponentDisplayName;
 
-    const mutationString =
-      mutation.mutationString || mutation.document.loc.source.body;
+    const mutationString = mutation.mutationString || print(mutation.document);
 
     return (
       <div className={classnames("main", { loading: mutation.loading })}>

--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -13,9 +13,7 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
-  const queryName = getOperationName(
-    parse(query.queryString || query.document.loc.source.body),
-  );
+  const queryName = getOperationName(parse(query.queryString || query.document.loc.source.body));
   if (queryName === null) {
     return queryId;
   }

--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -5,6 +5,7 @@ import sortBy from "lodash.sortby";
 import classnames from "classnames";
 import { getOperationName } from "apollo-utilities";
 import { parse } from "graphql/language/parser";
+import { print } from "graphql/language/printer";
 import { GraphqlCodeBlock } from "graphql-syntax-highlighter-react";
 import { Sidebar } from "../Sidebar";
 import Warning from "../Images/Warning";
@@ -12,7 +13,9 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
-  const queryName = getOperationName(parse(query.queryString || query.document.loc.source.body));
+  const queryName = getOperationName(
+    parse(query.queryString || query.document.loc.source.body),
+  );
   if (queryName === null) {
     return queryId;
   }
@@ -186,7 +189,7 @@ class WatchedQuery extends React.Component {
       query.metadata.component.displayName;
     const displayName = componentDisplayName || reactComponentDisplayName;
 
-    const queryString = query.queryString || query.document.loc.source.body;
+    const queryString = query.queryString || print(query.document);
 
     return (
       <div className={classnames("main", { loading: query.loading })}>


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
This is a fix to the changes in #125.

This fixes an issue that my team is running in to that is blocking us from using the dev tools and especially the `"Run in GraphiQL"` feature.

The `query.document.loc.source.body` will only include the query and not any of the fragments. My solution was the print the entire AST to a string. 

Let me know if there's anything else you need from me. Thanks!

Notice in the screenshot that the fragments are missing from the document that is loaded into GraphiQL. 
![screenshot 2018-07-12 18 15 15](https://user-images.githubusercontent.com/682132/42662432-959bf442-85ff-11e8-97e7-d02883566450.png)
