### PR TITLE
Set initial state to empty if queryManager does not exist

### DIFF
--- a/src/backend/broadcastQueries.js
+++ b/src/backend/broadcastQueries.js
@@ -17,8 +17,12 @@ export const initBroadCastEvents = (hook, bridge) => {
   bridge.on("panel:ready", () => {
     const client = hook.ApolloClient;
     const initial = {
-      queries: client.queryManager.queryStore.getStore(),
-      mutations: client.queryManager.mutationStore.getStore(),
+      queries: client.queryManager
+        ? client.queryManager.queryStore.getStore()
+        : {},
+      mutations: client.queryManager
+        ? client.queryManager.mutationStore.getStore()
+        : {},
       inspector: client.cache.extract(true),
     };
     bridge.send("broadcast:new", JSON.stringify(initial));


### PR DESCRIPTION
This is an attempt to fix https://github.com/apollographql/apollo-client-devtools/issues/104.

When the dev tools load and the client has yet to run a query, the `panel:ready` event handler blindly tries to get the `queryStore` and the `mutationStore` from the `queryManager` even though that property is not set on the client object until a query or mutation gets run.

The solution was to follow the same logic that gets used in [initQueryManager()](https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/ApolloClient.ts#L402) and set these values to be empty objects if the `queryManager` does not exist.

The logic I referenced above is used in all calls to the `devToolsHookCb` function in the client which is handled by the `logger` arrow function in the modified file which leads me to believe that this is safe change to make.