### PR TITLE
Remove Broken Firefox Addon Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo Client Devtools
 
-[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) | [Download for Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/)
+[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm)
 
 This repository contains the Apollo DevTools extension for Chrome & Firefox.
 


### PR DESCRIPTION
As mentioned in Issue #114 and #128, the link to the Firefox Addon Repository is broken. It appears the plugin has been pulled down. This is confusing to new contributors who discover this code base.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->