### PR TITLE
fix(WatchedQueries): Fix query name display

### DIFF
--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -13,6 +13,13 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
+  const queryDefinitions =
+    query && query.document && query.document.definitions;
+
+  if (queryDefinitions.length === 1) {
+    return queryDefinitions[0].name.value;
+  }
+
   const queryName = getOperationName(
     parse(query.queryString || query.document.loc.source.body),
   );


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
/label bug

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
### TL;DR
Watched Queries panel in the apollo-client-devtools does not display the correct title for queries stored in the same file. 

# Description
I noticed this bug the other day when refactoring our GQL query names. We have a few components that use multiple queries. We store these queries in one file, for example:
```
componentName/
    index.js // component code
    componentName.graphql // graphql queries used by componentName
```
`componentName.graphql` in this case looks like:
```
query exampleGQLQuery1($exampleId: ID!, $trendBy: TrendTimePeriod) {
    ...
}

query exampleGQLQuery2($exampleId: ID!) {
   ...
}
```

Inside `componentName/index.js` we import those queries via:
`import { exampleGQLQuery1, exampleGQLQuery2 } from './componentName.graphql';`

---

I wanted to check out these queries using the `apollo-client-devtools` (great tool btw! 😄), and I noticed that the Watched Queries tab could did correctly interpret the query names for multiple queries within the same file. The query string and variables were all correct, but the title (both in the query sidebar, and in the query panel after it has been selected) was wrong (it just uses the name of the first query in the file). 

Here are some examples (with some of our private schema data redacted):

## Broken

### Watched Queries Zero State
You can see the two queries listed in the sidebar with the same query name - when in reality, these are two distinct queries with different names stored in the same file
![zeroStateBroken](https://dl.dropboxusercontent.com/s/8qvt9r95t6lt3vo/Screenshot%202018-10-24%2009.43.50.png?dl=0
)

### Watched Queries: First Query Selected.
After selected the first query in the sidebar, you can see the query string and variables are correct (because this is the first query in the file, the title matches)
![query1Broken](https://dl.dropboxusercontent.com/s/l4rctkd5hrr051t/Screenshot%202018-10-24%2009.44.15.png?dl=0
)

### Watched Queries: Second Query Selected.
After selected the second query in the sidebar, you can see the query string and variables are correct, but the but the title in the sidebar, and in the panel is wrong (this is because the first query in the file is being used to generate all of the query titles.
![query2Broken](https://dl.dropboxusercontent.com/s/z2vjun6njtvqh84/Screenshot%202018-10-24%2009.44.05.png?dl=0
)

## Fixed

### Watched Queries Zero State
You can see the two queries listed in the sidebar with their correct query names
![zeroStateBroken](https://dl.dropboxusercontent.com/s/1t7nbiawb1bpmgl/Screenshot%202018-10-24%2009.45.19.png?dl=0
)

### Watched Queries: First Query Selected.
After selected the first query in the sidebar, you can see that the titles, query string and variables are correct.
![query1Broken](https://dl.dropboxusercontent.com/s/yl9jdqaorfgfjxr/Screenshot%202018-10-24%2009.45.25.png?dl=0
)

### Watched Queries: Second Query Selected.
After selected the second query in the sidebar, you can see that the titles, query string and variables are correct.
![query2Broken](https://dl.dropboxusercontent.com/s/mmjee014t6zbsqv/Screenshot%202018-10-24%2009.45.38.png?dl=0
)

Let me know what you think! Happy to provide more examples etc. as needed 😄 


