### PR TITLE
Fix issues preventing the queries tab from working

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog (started at 2.1.0)
 
+## 2.1.5
+
+* Fixes a query name parsing issue that lead to a blank page showing when
+  viewing the queries panel. <br/>
+  [@hwillson](https://github.com/hwillson) in [#149](https://github.com/apollographql/apollo-client-devtools/pull/149)
+
 ## 2.1.4
 
 * Removed all Google Analytics tracking. <br/>

--- a/src/devtools/components/WatchedQueries/WatchedQueries.js
+++ b/src/devtools/components/WatchedQueries/WatchedQueries.js
@@ -13,13 +13,27 @@ import Warning from "../Images/Warning";
 import "./WatchedQueries.less";
 
 const queryLabel = (queryId, query) => {
-  const queryName = getOperationName(
-    parse(query.queryString || query.document.loc.source.body),
-  );
-  if (queryName === null) {
-    return queryId;
+  let queryName;
+
+  if (query.queryString) {
+    // Parse the query string, then extract the query name.
+    queryName = getOperationName(parse(query.queryString));
+  } else if (query.document) {
+    // The query string has already been parsed (e.g. using `graphql-tag`)
+    // so extract the query name from the parsed document.
+    queryName = getOperationName(query.document);
   }
-  return `${queryName}`;
+
+  // If we haven't been able to find the query name, make one last
+  // attempt to parse and pull it from the source of a document
+  // (if it exsts).
+  if (!queryName && query.document.loc.source) {
+    queryName = getOperationName(parse(query.document.loc.source.body));
+  }
+
+  // If the query name can't be extracted, fallback on the query ID as the
+  // label.
+  return queryName || queryId;
 };
 
 class WatchedQueries extends React.Component {


### PR DESCRIPTION
Currently, the code to extract a query name to show in the queries panel, expects the incoming query to always have the `document.loc.source` attribute available. If this attribute isn't available, an exception is thrown, and the queries panel is displayed as a blank page. These changes adjust the logic used to extract a query label to be more flexible. The query name is now derived by attempting the following (in order):

1. Attempt to parse and extract a query name from an incoming query string.
2. Check to see if the incoming query has already been parsed; if so extract the query name from the parsed document (e.g. happens when using `graphql-tag`).
3. If the incoming query has already been parsed, but the query name can't be extracted from the result, see if the document includes the original query source. If so, try re-parsing it, and re-extracting the query name.
4. If all else fails, fallback on using the query ID as the query name.

Fixes #137.