### PR TITLE
Add missing "unsafe-eval" CSP setting

### DIFF
--- a/shells/webextension/manifest.json
+++ b/shells/webextension/manifest.json
@@ -12,7 +12,7 @@
   },
   "page_action": {},
   "content_security_policy":
-    "script-src 'self' https://devtools.apollodata.com/graphql; object-src 'self'",
+    "script-src 'self' 'unsafe-eval' https://devtools.apollodata.com/graphql; object-src 'self'",
   "permissions": ["tabs", "http://*/*", "https://*/*"],
   "devtools_page": "devtools-background.html",
   "background": {


### PR DESCRIPTION
The https://devtools.apollodata.com/graphql content security policy entry was missing the "unsafe-eval" setting, which lead to extension errors being logged by Chrome.
