### PR TITLE
Remove content security policy remote URL reference

### DIFF
--- a/shells/webextension/manifest.json
+++ b/shells/webextension/manifest.json
@@ -12,7 +12,7 @@
   },
   "page_action": {},
   "content_security_policy":
-    "script-src 'self' 'unsafe-eval' https://devtools.apollodata.com/graphql; object-src 'self'",
+    "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "permissions": ["tabs", "http://*/*", "https://*/*"],
   "devtools_page": "devtools-background.html",
   "background": {


### PR DESCRIPTION
https://devtools.apollodata.com/graphql doesn't need to be referenced in the content security policy config, and removing it should help with Firefox's security review process.