### PR TITLE
Visualization of tracing in query result

### DIFF
--- a/src/devtools/components/Tracing/Tracing.js
+++ b/src/devtools/components/Tracing/Tracing.js
@@ -1,0 +1,133 @@
+import React, { Component } from "react";
+import "./Tracing.less";
+
+export default class Tracing extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tracing: props.tracing,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      tracing: nextProps.tracing,
+    });
+  }
+
+  render() {
+    const tracing = this.state.tracing;
+
+    return (
+      <div>
+        {tracing ? (
+          <div className="tracingContainer">
+            {tracing.execution.resolvers.map(entry => (
+              <TracingEntry
+                path={entry.path}
+                startOffset={entry.startOffset}
+                duration={entry.duration}
+                totalDuration={tracing.duration}
+              />
+            ))}
+          </div>
+        ) : (
+          <div> No tracing information present </div>
+        )}
+      </div>
+    );
+  }
+}
+
+class TracingEntry extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      path: props.path,
+      startOffset: props.startOffset,
+      duration: props.duration,
+      totalDuration: props.totalDuration,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      path: nextProps.path,
+      startOffset: nextProps.startOffset,
+      duration: nextProps.duration,
+      totalDuration: nextProps.totalDuration,
+    });
+  }
+
+  pathDisplayable(path) {
+    return path.join(".");
+  }
+
+  durationDisplayable(duration) {
+    // convert to micro seconds (tracing durations are all in nano seconds)
+    const microSec = Math.round(duration / 1000);
+    if (microSec > 1000000) {
+      // if more than 1 second, return seconds with one decimal
+      return Math.round(microSec / 100000) / 10 + " s";
+    } else if (microSec > 1000) {
+      // if more than 1 ms, return ms
+      return Math.round(microSec / 1000) + " ms";
+    } else {
+      // else, return micro seconds
+      return microSec + " µs";
+    }
+  }
+
+  barWidthRatio(duration, totalDuration) {
+    const pathWidth = this.pathWidthRatio();
+    const durationWidth = this.durationWidthRatio();
+    const maxWidthForBar = 1.0 - pathWidth - durationWidth;
+    return duration / totalDuration * maxWidthForBar;
+  }
+
+  barOffsetRatio(startOffset, totalDuration) {
+    return (
+      this.pathWidthRatio() + this.barWidthRatio(startOffset, totalDuration)
+    );
+  }
+
+  pathWidthRatio() {
+    // buffer 10% width for path label
+    return 0.1;
+  }
+
+  durationWidthRatio() {
+    // buffer 5% width for duration label
+    return 0.05;
+  }
+
+  render() {
+    const { path, startOffset, duration, totalDuration } = this.state;
+    const pathLabel = this.pathDisplayable(path);
+    const durationLabel = this.durationDisplayable(this.state.duration);
+    const barWidth = this.barWidthRatio(duration, totalDuration);
+    const barOffset = this.barOffsetRatio(startOffset, totalDuration);
+
+    const offsetPercentage = barOffset * 100;
+    const barWidthPercentage = barWidth * 100;
+
+    return (
+      <div className="tracingRow">
+        <div style={{ width: `${offsetPercentage}%` }}>
+          <div className="tracingPath">{pathLabel}</div>
+        </div>
+
+        <div
+          className="tracingBarContainer"
+          style={{ width: `${barWidthPercentage}%` }}
+        >
+          <div className="tracingBar" />
+        </div>
+
+        <div className="tracingDuration">{durationLabel}</div>
+      </div>
+    );
+  }
+}

--- a/src/devtools/components/Tracing/Tracing.less
+++ b/src/devtools/components/Tracing/Tracing.less
@@ -1,0 +1,31 @@
+.tracingContainer {
+  max-height: 300px;
+  overflow-y: scroll;
+}
+
+.tracingRow {
+  display: flex;
+}
+
+.tracingPath {
+  font-size: 10px;
+  float: right;
+  padding-right: 5px;
+}
+
+.tracingBarContainer {
+  min-width: 1px;
+}
+
+.tracingBar {
+  margin-top: 3px;
+  height: 6px;
+  width: 100%;
+  background: #22a699;
+}
+
+.tracingDuration {
+  font-size: 10px;
+  padding-left: 5px;
+  color: #D64292;
+}

--- a/src/devtools/components/Tracing/index.js
+++ b/src/devtools/components/Tracing/index.js
@@ -1,0 +1,2 @@
+import Tracing from "./Tracing";
+export default Tracing;


### PR DESCRIPTION
**Why:**
Tracing [1] is optionally returned from GraphQL servers but is hard to interpret without visualization.

**What:**
Tracing visualization rendered in the footer of the GraphiQL result window. Each tracing.execution.resolvers entry is rendered as a row with a bar together with resolver path label and duration.

**Testing:**
- Chrome Browser, Version 71.0.3578.98 (Official Build) (64-bit)
- Mac OSX 10.12.6
- GraphQL-java server with and without tracing turned on.

**Left to do:**
- Resizable panel where tracing visualization resides (currently max-height set to 300px to not consume all of the result window).
- Clear the tracing visualization when new query has been triggered.

[1] https://github.com/apollographql/apollo-tracing