### PR TITLE
Patched: Issue #110

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 - Integrate OneGraph's GraphiQL Explorer.  <br/>
   [@sgrove](https://github.com/sgrove) in [#199](https://github.com/apollographql/apollo-client-devtools/pull/199)
+- Make sure devtools can be used when the transport layer is websockets
+  only.  <br/>
+  [@kamerontanseli](https://github.com/kamerontanseli) in [#163](https://github.com/apollographql/apollo-client-devtools/pull/163) 
 
 ## 2.2.1
 


### PR DESCRIPTION
Fixes #110 

Error when full websockets server is in use:
```javascript
{
  "errors": [
    {
      "message": "n(...).map is not a function",
      "locations": [
        "TypeError: n(...).map is not a function\n    at e.request (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:38659)\n    at chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:3681\n    at e.request (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:38421)\n    at chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:3681\n    at chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:38085\n    at new s (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:4855)\n    at l.subscribe (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:6185)\n    at n.<anonymous> (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:38914)\n    at n.t.emit (chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:52786)\n    at chrome-extension://jdkknkkbebbapilgoeccciglkfbmbnfm/dist/backend.js:1:19519"
      ]
    }
  ]
}
```

Patch `forward(operation) was returning null which caused .map() to fail`: 
```javascript
const schemaLink = () =>
  new ApolloLink((operation, forward) => {
    return new Observable(observer => { // wrap result in an observable
      const ob = forward(operation); 
      if (ob) { // check if forward returns not null
        return forward(operation).subscribe(result => {
          let { schemas = [] } = operation.getContext();
          try {
            result.extensions = Object.assign({}, result.extensions, {
              schemas: schemas.concat([apolloClientSchema]),
            });
          } catch (error) {
            console.error(error);
          }
          return observer.next(result); // return the result
        });
      }
      return () => {
        if (ob) ob.unsubscribe();
      };
    });
  });
```