### PR TITLE
AC-11 Support AC local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist
 !./dist/.gitkeep
 *.zip
+.DS_Store

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 - Include local fields and types in GraphiQL ([#172](https://github.com/apollographql/apollo-client-devtools/issues/172), [#159](https://github.com/apollographql/apollo-client-devtools/issues/159))
   [@justinanastos](https://github.com/justinanastos) in [#188](https://github.com/apollographql/apollo-client-devtools/pull/188)
 
+- Use Apollo Client v2.5 local state 🎉 ([#apollographql/apollo-client#4361](https://github.com/apollographql/apollo-client/pull/4361))
+  [@cheapsteak](https://github.com/cheapsteak) and [@hwillson](https://github.com/hwillson) in [#166](https://github.com/apollographql/apollo-client-devtools/pull/166)
+
 ## 2.1.9
 
 - Eliminate use of `window.localStorage`, removing the need for 3rd party cookies ([#118](https://github.com/apollographql/apollo-client-devtools/issues/118), [#142](https://github.com/apollographql/apollo-client-devtools/issues/142))

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/async": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.46.tgz",
-      "integrity": "sha512-G4pYI5fcrmy6/NpTUHxTV8KOJgt7xO4jU7Itx3hA+AsBiECf78vFIJdRSWM6pHIskmKfCmJ0zGVbQJuKUooEQg==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.50.tgz",
+      "integrity": "sha512-VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==",
       "optional": true
     },
     "@types/graphql": {
@@ -425,24 +425,40 @@
       }
     },
     "apollo-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.2.0.tgz",
-      "integrity": "sha512-PSocHEbRoubHIV+GD/bHMACFstbEv9a4FLgu41d2djpwAIIiT37qgnfLbnvY7BlME0vKc7HIV6sYjLY3xnjY4Q==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.5.tgz",
+      "integrity": "sha512-nUm06EGa4TP/IY68OzmC3lTD32TqkjLOQdb69uYo+lHl8NnwebtrAw3qFtsQtTEz6ueBp/Z/HasNZng4jwafVQ==",
       "requires": {
-        "@types/async": "2.0.46",
-        "@types/zen-observable": "^0.5.3",
-        "apollo-cache": "^1.1.0",
+        "@types/async": "2.0.50",
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.1.20",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "^1.0.4",
+        "apollo-utilities": "1.0.25",
         "symbol-observable": "^1.0.2",
-        "zen-observable": "^0.7.0"
+        "zen-observable": "^0.8.0"
       },
       "dependencies": {
+        "@types/zen-observable": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+          "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+        },
+        "apollo-cache": {
+          "version": "1.1.20",
+          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.20.tgz",
+          "integrity": "sha512-+Du0/4kUSuf5PjPx0+pvgMGV12ezbHA8/hubYuqRQoy/4AWb4faa61CgJNI6cKz2mhDd9m94VTNKTX11NntwkQ==",
+          "requires": {
+            "apollo-utilities": "^1.0.25"
+          }
+        },
         "apollo-utilities": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-          "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
+          "version": "1.0.25",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.25.tgz",
+          "integrity": "sha512-AXvqkhni3Ir1ffm4SA1QzXn8k8I5BBl4PVKEyak734i4jFdp+xgfUyi2VCqF64TJlFTA/B73TRDUvO2D+tKtZg==",
+          "requires": {
+            "fast-json-stable-stringify": "^2.0.0"
+          }
         }
       }
     },
@@ -469,11 +485,22 @@
       }
     },
     "apollo-link-dedup": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.5.tgz",
-      "integrity": "sha512-KxBC8RapBctNX7o/bxMi5LdLA5VhD9ng8Td0tG+zlib5WV5wMERBCclgd9LqRdt1CkxJ/gsrTfBh38LcVhpWvg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz",
+      "integrity": "sha512-tpUI9lMZsidxdNygSY1FxflXEkUZnvKRkMUsXXuQUNoSLeNtEvUX7QtKRAl4k9ubLl8JKKc9X3L3onAFeGTK8w==",
       "requires": {
-        "apollo-link": "^1.0.7"
+        "apollo-link": "^1.2.3"
+      },
+      "dependencies": {
+        "apollo-link": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
+          "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
+          "requires": {
+            "apollo-utilities": "^1.0.0",
+            "zen-observable-ts": "^0.8.10"
+          }
+        }
       }
     },
     "apollo-link-error": {
@@ -2636,7 +2663,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.0.7",
@@ -3398,6 +3426,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
       "requires": {
         "domelementtype": "~1.1.1",
         "entities": "~1.1.1"
@@ -3406,7 +3435,8 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
         }
       }
     },
@@ -3419,7 +3449,8 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
     },
     "domhandler": {
       "version": "2.1.0",
@@ -3434,6 +3465,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -4392,8 +4424,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -7347,7 +7378,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isemail": {
       "version": "1.2.0",
@@ -9996,7 +10028,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
@@ -10385,6 +10418,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10857,7 +10891,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "safe-json-stringify": {
       "version": "1.0.4",
@@ -11807,6 +11842,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -11955,9 +11991,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "4.0.2",
@@ -12915,7 +12951,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utila": {
       "version": "0.4.0",
@@ -14362,9 +14399,17 @@
       }
     },
     "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
+      "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
+      "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
+      "requires": {
+        "zen-observable": "^0.8.0"
+      }
     },
     "zip-dir": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5947,11 +5947,18 @@
       }
     },
     "graphql": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.11.7.tgz",
-      "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.1.1.tgz",
+      "integrity": "sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==",
       "requires": {
-        "iterall": "1.1.3"
+        "iterall": "^1.2.2"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+        }
       }
     },
     "graphql-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/async": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.50.tgz",
-      "integrity": "sha512-VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==",
-      "optional": true
-    },
     "@types/graphql": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.7.tgz",
@@ -393,49 +387,38 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.0.tgz",
-      "integrity": "sha512-ILs1/GCyAv8RRMansOqpENnsJMCc1w6UQKVY6vTxJBpUDpGO6B6/UbIaWM0esat9cf92a7yx13/BoauFRzwqzw==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.26.tgz",
+      "integrity": "sha512-JKFHijwkhXpcQ3jOat+ctwiXyjDhQgy0p6GSaj7zG+or+ZSalPqUnPzFRgRwFLVbYxBKJgHCkWX+2VkxWTZzQQ==",
       "requires": {
-        "apollo-utilities": "^1.0.4"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-          "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
-        }
+        "apollo-utilities": "^1.1.3",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz",
-      "integrity": "sha512-Gy9g4RZUfIJwxaZuMF3ZqplYaiFSfgJYmepYTIP+zL+9dqV1Er8EIICJqVlc4T2uWXHQ9U01iK5Hu1g9pV85tg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.4.3.tgz",
+      "integrity": "sha512-p9KGtEZ9Mlb+FS0UEaxR8WvKOijYV0c+TXlhC/XZ3/ltYvP1zL3b1ozSOLGR9SawN2895Fc7QDV5nzPpihV0rA==",
       "requires": {
-        "apollo-cache": "^1.1.0",
-        "apollo-utilities": "^1.0.4",
-        "graphql-anywhere": "^4.1.1"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-          "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
-        }
+        "apollo-cache": "^1.1.26",
+        "apollo-utilities": "^1.1.3",
+        "optimism": "^0.6.9",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-client": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.5.tgz",
-      "integrity": "sha512-nUm06EGa4TP/IY68OzmC3lTD32TqkjLOQdb69uYo+lHl8NnwebtrAw3qFtsQtTEz6ueBp/Z/HasNZng4jwafVQ==",
+      "version": "2.5.0-rc.3",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.5.0-rc.3.tgz",
+      "integrity": "sha512-Kgwl0KluOWOcbI23Q8/v5M+0Cq0p+e7Y/v8g+OHkMA/uIdm3BIgnmy2P15pf00VzIWtSQgALpc6WITXWrg/Dqw==",
       "requires": {
-        "@types/async": "2.0.50",
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.1.20",
+        "apollo-cache": "1.2.0-rc.2",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "1.0.25",
+        "apollo-utilities": "1.2.0-rc.2",
         "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       },
       "dependencies": {
@@ -445,19 +428,22 @@
           "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
         },
         "apollo-cache": {
-          "version": "1.1.20",
-          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.20.tgz",
-          "integrity": "sha512-+Du0/4kUSuf5PjPx0+pvgMGV12ezbHA8/hubYuqRQoy/4AWb4faa61CgJNI6cKz2mhDd9m94VTNKTX11NntwkQ==",
+          "version": "1.2.0-rc.2",
+          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.2.0-rc.2.tgz",
+          "integrity": "sha512-R3O5M6cowa61Dsm2u9k3gdSWmuovTzCgsPcPHnu8yMtepNrfzGySJbCkfpS1g6vnrQoR/q7X3FkxaYMJkVpB5w==",
           "requires": {
-            "apollo-utilities": "^1.0.25"
+            "apollo-utilities": "^1.2.0-rc.2",
+            "tslib": "^1.9.3"
           }
         },
         "apollo-utilities": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.25.tgz",
-          "integrity": "sha512-AXvqkhni3Ir1ffm4SA1QzXn8k8I5BBl4PVKEyak734i4jFdp+xgfUyi2VCqF64TJlFTA/B73TRDUvO2D+tKtZg==",
+          "version": "1.2.0-rc.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.0-rc.2.tgz",
+          "integrity": "sha512-DD/kojZKd16ooa78t70E3McWwbirWJ2+uKVk4e5PeOMbUtCzBHnO9mlZtVg8ve6QsKaxUhulKFC959c15ekd2g==",
           "requires": {
-            "fast-json-stable-stringify": "^2.0.0"
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.2.1",
+            "tslib": "^1.9.3"
           }
         }
       }
@@ -485,20 +471,19 @@
       }
     },
     "apollo-link-dedup": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz",
-      "integrity": "sha512-tpUI9lMZsidxdNygSY1FxflXEkUZnvKRkMUsXXuQUNoSLeNtEvUX7QtKRAl4k9ubLl8JKKc9X3L3onAFeGTK8w==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.15.tgz",
+      "integrity": "sha512-14/+Tg7ogcYVrvZa8C7uBQIvX2B/dCKSnojI41yDYGp/t2eWD5ITCWdgjhciXpi0Ij6z+NRyMEebACz3EOwm4w==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.8"
       },
       "dependencies": {
         "apollo-link": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
-          "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.8.tgz",
+          "integrity": "sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==",
           "requires": {
-            "apollo-utilities": "^1.0.0",
-            "zen-observable-ts": "^0.8.10"
+            "zen-observable-ts": "^0.8.15"
           }
         }
       }
@@ -521,9 +506,13 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-      "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.1.3.tgz",
+      "integrity": "sha512-pF9abhiClX5gfj/WFWZh8DiI33nOLGxRhXH9ZMquaM1V8bhq1WLFPt2QjShWH3kGQVeIGUK+FQefnhe+ZaaAYg==",
+      "requires": {
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.9.3"
+      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -5965,21 +5954,6 @@
         "iterall": "1.1.3"
       }
     },
-    "graphql-anywhere": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz",
-      "integrity": "sha512-CMbuqNbp6nfHfOHswrDuEed+MxDSnLppHKjjte447P6fllqZi69D2bS/3QSfK/KONSgvpk3ptxNi4fR6WQFcSQ==",
-      "requires": {
-        "apollo-utilities": "^1.0.4"
-      },
-      "dependencies": {
-        "apollo-utilities": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.4.tgz",
-          "integrity": "sha512-QnxSxRuJLCpa91P2Tzi3PCdpPydpBEawsHedr/hW7QrgOpn1fOicxgVrzhxt/au9rXSopwyDTBsGa7wEvz+DQQ=="
-        }
-      }
-    },
     "graphql-config": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-1.1.4.tgz",
@@ -6312,9 +6286,12 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6731,6 +6708,11 @@
       "dev": true,
       "optional": true
     },
+    "immutable-tuple": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/immutable-tuple/-/immutable-tuple-0.4.10.tgz",
+      "integrity": "sha512-45jheDbc3Kr5Cw8EtDD+4woGRUV0utIrJBZT8XH0TPZRfm8tzT0/sLGGzyyCCFqFMG5Pv5Igf3WY/arn6+8V9Q=="
+    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -6938,6 +6920,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -7837,6 +7820,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isfunction": {
       "version": "3.0.8",
@@ -8804,6 +8792,14 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.6.9.tgz",
+      "integrity": "sha512-xoQm2lvXbCA9Kd7SCx6y713Y7sZ6fUc5R6VYpoL5M6svKJbTuvtNopexK8sO8K4s0EOUYHuPN2+yAEsNyRggkQ==",
+      "requires": {
+        "immutable-tuple": "^0.4.9"
       }
     },
     "optionator": {
@@ -10304,16 +10300,28 @@
       }
     },
     "react-apollo": {
-      "version": "2.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.1.0-beta.0.tgz",
-      "integrity": "sha512-SfYihNqGhbKaXFDkfpETH9y7lMBIRYz4dtOuX9CrKYQeBBlEIjVxyoySoSeomQGAE8TX0NVg/AktQ+7Bel5URQ==",
+      "version": "2.5.0-rc.3",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.5.0-rc.3.tgz",
+      "integrity": "sha512-2W90yHi/AGl7BNPaGg+oGa+Voy6Nw8O3zKLsZdA+V4suh9g0ePlEp7m3WSdZpjENdAaDCLRt1Qy1nSekh0H1sw==",
       "requires": {
-        "apollo-link": "^1.0.6",
-        "fbjs": "^0.8.16",
-        "hoist-non-react-statics": "^2.3.1",
-        "invariant": "^2.2.2",
-        "lodash": "4.17.4",
-        "prop-types": "^15.6.0"
+        "apollo-utilities": "^1.2.0-rc.2",
+        "hoist-non-react-statics": "^3.0.0",
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.6.0",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.2.0-rc.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.0-rc.2.tgz",
+          "integrity": "sha512-DD/kojZKd16ooa78t70E3McWwbirWJ2+uKVk4e5PeOMbUtCzBHnO9mlZtVg8ve6QsKaxUhulKFC959c15ekd2g==",
+          "requires": {
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.2.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "react-art": {
@@ -12359,6 +12367,19 @@
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
+      "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -14399,14 +14420,14 @@
       }
     },
     "zen-observable": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
-      "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ=="
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
+      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g=="
     },
     "zen-observable-ts": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
-      "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz",
+      "integrity": "sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==",
       "requires": {
         "zen-observable": "^0.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "arson": "^0.2.5",
     "classnames": "^2.2.5",
     "graphiql": "^0.11.11",
-    "graphql": "^0.11.7",
+    "graphql": "^14.1.1",
     "graphql-syntax-highlighter-react": "^0.3.0",
     "graphql-tag": "^2.6.1",
     "graphql-tools": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "webpack-dev-server": "^2.11.1"
   },
   "dependencies": {
-    "apollo-cache-inmemory": "^1.1.5",
-    "apollo-client": "^2.4.3",
+    "apollo-cache-inmemory": "^1.4.0-alpha.12",
+    "apollo-client": "^2.5.0-rc.3",
     "apollo-link": "^1.0.7",
     "apollo-link-error": "^1.0.3",
-    "apollo-utilities": "^1.0.4",
+    "apollo-utilities": "^1.1.0-alpha.10",
     "arson": "^0.2.5",
     "classnames": "^2.2.5",
     "graphiql": "^0.11.11",
@@ -62,7 +62,7 @@
     "lodash.uniqby": "^4.7.0",
     "prop-types": "^15.6.0",
     "react": "^16.8.2",
-    "react-apollo": "^2.1.0-beta.0",
+    "react-apollo": "^2.5.0-rc.3",
     "react-dom": "^16.8.2",
     "uuid": "^3.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "apollo-cache-inmemory": "^1.1.5",
-    "apollo-client": "^2.2.0",
+    "apollo-client": "^2.4.3",
     "apollo-link": "^1.0.7",
     "apollo-link-error": "^1.0.3",
     "apollo-utilities": "^1.0.4",

--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -109,7 +109,7 @@ export const initLinkEvents = (hook, bridge) => {
       // is being used.
 
       const supportsApolloClientLocalState =
-        typeof apolloClient.getTypeDefs === "function";
+        typeof apolloClient.typeDefs !== "undefined";
 
       if (!supportsApolloClientLocalState) {
         // Supports `apollo-link-state`.
@@ -135,7 +135,7 @@ export const initLinkEvents = (hook, bridge) => {
 
       // Supports Apollo Client local state.
 
-      const typeDefs = apolloClient.getTypeDefs();
+      const typeDefs = apolloClient.typeDefs;
 
       // When using `apollo-link-state`, client supplied typeDefs (for a
       // local only schema) are extracted by re-using the same Apollo Link

--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -84,7 +84,7 @@ export const initLinkEvents = (hook, bridge) => {
       const userLink = apolloClient.link;
       const cache = apolloClient.cache;
       let schemas = [];
-      let obs;
+      let operationExecution$;
       const queryAst = gql(query);
 
       // Devtools can currently be used with 2 versions of local state
@@ -135,7 +135,7 @@ export const initLinkEvents = (hook, bridge) => {
           queryAst.definitions.length > 0 &&
           queryAst.definitions[0].operation === "mutation"
         ) {
-          obs = new Observable(observer => {
+          operationExecution$ = new Observable(observer => {
             dtApolloClient
               .mutate({
                 mutation: queryAst,
@@ -146,7 +146,7 @@ export const initLinkEvents = (hook, bridge) => {
               });
           });
         } else {
-          obs = dtApolloClient.watchQuery({
+          operationExecution$ = dtApolloClient.watchQuery({
             query: queryAst,
             variables,
           });
@@ -161,7 +161,7 @@ export const initLinkEvents = (hook, bridge) => {
           schemaLink(),
           userLink,
         ]);
-        obs = execute(devtoolsLink, {
+        operationExecution$ = execute(devtoolsLink, {
           query: queryAst,
           variables,
           operationName,
@@ -169,7 +169,7 @@ export const initLinkEvents = (hook, bridge) => {
         });
       }
 
-      obs.subscribe({
+      operationExecution$.subscribe({
         next(data) {
           if (schemas && schemas.length > 0) {
             // `apollo-link-state` gets the local schema added to the result

--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -123,7 +123,7 @@ export const initLinkEvents = (hook, bridge) => {
         // devtools IntrospectionQuery's (and potentially other future devtool
         // only queries) show up in the "Queries" panel as watched queries.
         // This means devtools specific queries will use their own query store.
-        const dtApolloClient = new ApolloClient({
+        const apolloClientReplica = new ApolloClient({
           link: userLink,
           cache,
           typeDefs,
@@ -136,7 +136,7 @@ export const initLinkEvents = (hook, bridge) => {
           queryAst.definitions[0].operation === "mutation"
         ) {
           operationExecution$ = new Observable(observer => {
-            dtApolloClient
+            apolloClientReplica
               .mutate({
                 mutation: queryAst,
                 variables,
@@ -146,7 +146,7 @@ export const initLinkEvents = (hook, bridge) => {
               });
           });
         } else {
-          operationExecution$ = dtApolloClient.watchQuery({
+          operationExecution$ = apolloClientReplica.watchQuery({
             query: queryAst,
             variables,
           });

--- a/src/backend/typeDefs.js
+++ b/src/backend/typeDefs.js
@@ -1,0 +1,19 @@
+import { DocumentNode, print } from "graphql";
+
+function normalizeTypeDefs(typeDefs) {
+  const defs = Array.isArray(typeDefs) ? typeDefs : [typeDefs];
+  return defs
+    .map(typeDef => (typeof typeDef === "string" ? typeDef : print(typeDef)))
+    .map(str => str.trim())
+    .join("\n");
+}
+
+export function buildSchemasFromTypeDefs(typeDefs) {
+  let schemas;
+  if (typeDefs) {
+    const directives = "directive @client on FIELD";
+    const definition = normalizeTypeDefs(typeDefs);
+    schemas = [{ definition, directives }];
+  }
+  return schemas;
+}


### PR DESCRIPTION
99.9% of this was done by Hugh, really appreciated the extremely thorough comments
I just moved a few lines around and double checked that it's working against our full stack tutorial (which uses AC local state) and pupstagram (which uses link-state)

I did find that running link-state mutations doesn't work (in the case of pupstagram, running the `toggleLikedPhoto` mutation results in a `getCacheKey is not a function` error), but it's broken the same way in the currently published version of devtools as well, so it's likely that it hasn't worked in the past

I'm not sure if there's much else worth saying here. The meat of the changes is in `links.js`, and Hugh's comments do a great job of explaining what and why