### PR TITLE
Publish built extension (dist/)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+*.zip

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "cd shells && zip -r -FS ../dist/chrome.zip webextension -x *src/* -x *webpack.config.js",
     "zip:firefox":
       "web-ext build -s shells/webextension -a dist -i src --overwrite-dest",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "prepublish": "npm run build"
   },
   "lint-staged": {
     "*.{ts*,js*,json,md}": ["prettier --write", "git add"]


### PR DESCRIPTION
Fixes #169

Can see the built files here
https://unpkg.com/apollo-client-devtools@2.1.7-alpha.2/shells/webextension/dist/

This will allow other projects to import this module's files more easily (since node_modules are excluded from transpile by default)