### PR TITLE
Debounce broadcast messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 - Make sure devtools can be used when the transport layer is websockets
   only.  <br/>
   [@kamerontanseli](https://github.com/kamerontanseli) in [#163](https://github.com/apollographql/apollo-client-devtools/pull/163) 
+- Debounce broadcast messages to improve devtools responsiveness and 
+  memory usage.  <br/>
+  [@thomassuckow](https://github.com/thomassuckow) in [#173](https://github.com/apollographql/apollo-client-devtools/pull/173)
 
 ## 2.2.1
 

--- a/src/backend/broadcastQueries.js
+++ b/src/backend/broadcastQueries.js
@@ -1,18 +1,62 @@
 export const initBroadCastEvents = (hook, bridge) => {
+  //Counters for diagnostics
+  let counter = 0;
+  let sent = 0;
+  //Next broadcast to be sent
+  let enqueued = null;
+  //Whether backend is ready for another broadcast
+  let acknowledged = true;
+  //Threshold for warning about state size in Megabytes
+  let warnMB = 10;
+
+  //Minimize impact to webpage. Serializing large state could cause Jank
+  function scheduleBroadcast() {
+    acknowledged = false;
+    requestIdleCallback(sendBroadcast, { timeout: 120 /*max 2min*/ });
+  }
+
+  //Send the Apollo broadcast to the devtools
+  function sendBroadcast() {
+    sent++;
+    const msg = JSON.stringify(enqueued);
+    bridge.send("broadcast:new", msg);
+    enqueued = null;
+
+    if (msg.length > warnMB * 1000000) {
+      const currentMB = msg.length / 1000000;
+      console.warn(
+        "Apollo DevTools serialized state is " +
+          currentMB.toFixed(1) +
+          "MB. This may cause performance degradation.",
+      );
+      warnMB = currentMB * 2; //Warn again if it doubles.
+    }
+  }
+
   let logger = ({
     state: { queries, mutations },
     // XXX replace with universal store format compat way of this
     dataWithOptimisticResults: inspector,
   }) => {
-    bridge.send(
-      "broadcast:new",
-      JSON.stringify({
-        queries,
-        mutations,
-        inspector,
-      }),
-    );
+    counter++;
+    enqueued = {
+      counter,
+      queries,
+      mutations,
+      inspector,
+    };
+    if (acknowledged) {
+      scheduleBroadcast();
+    }
   };
+
+  //The backend has acknoledged reciept of a broadcast
+  bridge.on("broadcast:ack", data => {
+    acknowledged = true;
+    if (enqueued) {
+      scheduleBroadcast();
+    }
+  });
 
   bridge.on("panel:ready", () => {
     const client = hook.ApolloClient;

--- a/src/backend/broadcastQueries.js
+++ b/src/backend/broadcastQueries.js
@@ -1,23 +1,24 @@
 export const initBroadCastEvents = (hook, bridge) => {
-  //Counters for diagnostics
+  // Counters for diagnostics
   let counter = 0;
-  let sent = 0;
-  //Next broadcast to be sent
+
+  // Next broadcast to be sent
   let enqueued = null;
-  //Whether backend is ready for another broadcast
+
+  // Whether backend is ready for another broadcast
   let acknowledged = true;
-  //Threshold for warning about state size in Megabytes
+
+  // Threshold for warning about state size in Megabytes
   let warnMB = 10;
 
-  //Minimize impact to webpage. Serializing large state could cause Jank
+  // Minimize impact to webpage. Serializing large state could cause jank
   function scheduleBroadcast() {
     acknowledged = false;
     requestIdleCallback(sendBroadcast, { timeout: 120 /*max 2min*/ });
   }
 
-  //Send the Apollo broadcast to the devtools
+  // Send the Apollo broadcast to the devtools
   function sendBroadcast() {
-    sent++;
     const msg = JSON.stringify(enqueued);
     bridge.send("broadcast:new", msg);
     enqueued = null;
@@ -25,17 +26,16 @@ export const initBroadCastEvents = (hook, bridge) => {
     if (msg.length > warnMB * 1000000) {
       const currentMB = msg.length / 1000000;
       console.warn(
-        "Apollo DevTools serialized state is " +
-          currentMB.toFixed(1) +
-          "MB. This may cause performance degradation.",
+        `Apollo DevTools serialized state is ${currentMB.toFixed(1)} MB. ` +
+        "This may cause performance degradation.",
       );
-      warnMB = currentMB * 2; //Warn again if it doubles.
+      // Warn again if it doubles
+      warnMB = currentMB * 2;
     }
   }
 
   let logger = ({
     state: { queries, mutations },
-    // XXX replace with universal store format compat way of this
     dataWithOptimisticResults: inspector,
   }) => {
     counter++;
@@ -50,7 +50,7 @@ export const initBroadCastEvents = (hook, bridge) => {
     }
   };
 
-  //The backend has acknoledged reciept of a broadcast
+  // The backend has acknowledged receipt of a broadcast
   bridge.on("broadcast:ack", data => {
     acknowledged = true;
     if (enqueued) {

--- a/src/devtools/components/Panel.js
+++ b/src/devtools/components/Panel.js
@@ -37,9 +37,9 @@ const UpgradeNotice = ({ version }) => (
   <Shell>
     <h1 style={{ color: "white" }}>Your Apollo Client needs updating!</h1>
     <h3 style={{ color: "white" }}>
-      We&apos;ve detected your version of Apollo Client to be v{version}. The Apollo
-      Devtools requires version 2.0.0 or greater. Luckily, upgrading is pretty
-      painless and brings a whole bunch of new features! To learn how to
+      We&apos;ve detected your version of Apollo Client to be v{version}. The
+      Apollo Devtools requires version 2.0.0 or greater. Luckily, upgrading is
+      pretty painless and brings a whole bunch of new features! To learn how to
       upgrade, check out the migration guide{" "}
       <a
         style={{ color: "white" }}
@@ -113,6 +113,7 @@ export default class Panel extends Component {
 
     this.props.bridge.on("broadcast:new", _data => {
       const data = JSON.parse(_data);
+      if (data.counter) this.props.bridge.send("broadcast:ack", data.counter);
       this.setState(({ tabData }) => ({
         tabData: Object.assign({}, tabData, data),
         notFound: false,


### PR DESCRIPTION
* Drops broadcast messages that are fired in rapid succession
* Offloads serialization to requestIdleCallback
* Reduces number of broadcasts sent to devtools in my test cases by over 90% (300 in a few seconds)
* Drastically improves responsiveness of devtools
* Drastically reduced memory usage of devtools (i.e. Fewer out of memory crashes 🙌🏻)