### PR TITLE
✨ add sourcemaps to build

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,10 @@
   <br>
   [@justinanastos](https://github.com/justinanastos)
   in [#178](https://github.com/apollographql/apollo-client-devtools/pull/178)
+- Add sourcemaps to build
+  <br>
+  [@justinanastos](https://github.com/justinanastos)
+  in [#179](https://github.com/apollographql/apollo-client-devtools/pull/179)
 
 ## 2.1.5
 

--- a/shells/webextension/webpack.config.js
+++ b/shells/webextension/webpack.config.js
@@ -20,6 +20,8 @@ if (process.env.NODE_ENV === "production") {
 }
 
 module.exports = {
+  devtool:
+    process.env.NODE_ENV === "production" ? "source-map" : "eval-source-map",
   entry: {
     hook: "./src/hook.js",
     devtools: "./src/devtools.js",


### PR DESCRIPTION
This will make error reporting a lot more useful because we won't be looking at minified code.

Relates to #107 	