### PR TITLE
🚑 fix empty cache crashing cache inspector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,10 @@
   <br>
   [@justinanastos](https://github.com/justinanastos)
   in [#179](https://github.com/apollographql/apollo-client-devtools/pull/179)
+- Fix empty cache crashing cache inspector ([#107](https://github.com/apollographql/apollo-client-devtools/issues/107))
+  <br>
+  [@justinanastos](https://github.com/justinanastos)
+  in [#177](https://github.com/apollographql/apollo-client-devtools/pull/177)
 
 ## 2.1.5
 

--- a/src/devtools/components/Inspector/Inspector.js
+++ b/src/devtools/components/Inspector/Inspector.js
@@ -254,7 +254,9 @@ class StoreTreeFieldSet extends React.Component {
   }
 
   getStoreObj() {
-    return this.context.inspectorContext.dataWithOptimistic[this.props.dataId];
+    return (
+      this.context.inspectorContext.dataWithOptimistic[this.props.dataId] || {}
+    );
   }
 
   getHighlightObj() {

--- a/src/devtools/components/Inspector/Inspector.js
+++ b/src/devtools/components/Inspector/Inspector.js
@@ -41,7 +41,10 @@ export default class Inspector extends React.Component {
     const sortedIdsWithoutRoot = unsortedIds
       .filter(id => id !== "ROOT_QUERY" && highlightedIds.indexOf(id) < 0)
       .sort();
-    const ids = [...highlightedIds, "ROOT_QUERY", ...sortedIdsWithoutRoot];
+    const ids =
+      sortedIdsWithoutRoot.length === 0
+        ? []
+        : [...highlightedIds, "ROOT_QUERY", ...sortedIdsWithoutRoot];
     const selectedId = this.state.selectedId || ids[0];
     this.setState({
       dataWithOptimistic,


### PR DESCRIPTION
This should hopefully cause the cache to stop crashing. It won't make it work any better because that's outside the scope.

Resolves #107 

I'd really like to add some tests around this, but that's outside the scope of resolving this critical issue.