### PR TITLE
🐛 fix document explorer crashing when `@client` directive is present

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,10 @@
   <br>
   [@justinanastos](https://github.com/justinanastos)
   in [#177](https://github.com/apollographql/apollo-client-devtools/pull/177)
+- Fix GraphiQL Documentation Explorer crashing with client schema extensions ([#107](https://github.com/apollographql/apollo-client-devtools/issues/107))
+  <br>
+  [@justinanastos](https://github.com/justinanastos)
+  in [#180](https://github.com/apollographql/apollo-client-devtools/pull/180)
 
 ## 2.1.5
 

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -60,7 +60,15 @@ export const createBridgeLink = bridge =>
           const directivesOnly = schemas
             .filter(x => !x.definition)
             .map(x => x.directives);
-          const definitions = schemas.filter(x => !!x.definition);
+          const definitions = schemas
+            .filter(x => !!x.definition)
+            // Filter out @client directives because they can't be parsed by
+            // `buildSchema`. I don't know if any other directives work; if they
+            // don't, this won't fix them. If they do, this won't break them.
+            .filter(
+              definition =>
+                definition.directives !== "directive @client on FIELD",
+            );
           const built = definitions.map(({ definition, directives = "" }) =>
             buildSchema(`${directives} ${definition}`),
           );


### PR DESCRIPTION
This will only fix the documentation explorer crashing for `@client` directives. This will not add client directives to the documentation explorer. If any other directives crash the documentation explorer, this won't fix them.

Resolves issue #132