### PR TITLE
Fix mutations tab

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Fix mutations tab crashing devtools ([#182](https://github.com/apollographql/apollo-client-devtools/issues/182))
+  [@justinanastos](https://github.com/justinanastos) in [#184](https://github.com/apollographql/apollo-client-devtools/pull/184)
+
 ## 2.1.7
 
 - Removed https://devtools.apollodata.com/graphql from the content security

--- a/src/devtools/components/Mutations/Mutations.js
+++ b/src/devtools/components/Mutations/Mutations.js
@@ -13,10 +13,9 @@ import Warning from "../Images/Warning";
 import "../WatchedQueries/WatchedQueries.less";
 
 const mutationLabel = (mutationId, mutation) => {
-  const mutationName = getOperationName(
-    parse(mutation.mutationString || mutation.document.loc.source.body),
-  );
-  if (mutationName === null) {
+  const mutationName = getOperationName(mutation.mutation);
+
+  if (!mutationName) {
     return mutationId;
   }
   return `${mutationName}`;
@@ -185,7 +184,7 @@ class WatchedMutation extends React.Component {
       mutation.metadata.component.displayName;
     const displayName = componentDisplayName || reactComponentDisplayName;
 
-    const mutationString = mutation.mutationString || print(mutation.document);
+    const mutationString = print(mutation.mutation);
 
     return (
       <div className={classnames("main", { loading: mutation.loading })}>

--- a/src/devtools/components/Mutations/Mutations.js
+++ b/src/devtools/components/Mutations/Mutations.js
@@ -13,7 +13,14 @@ import Warning from "../Images/Warning";
 import "../WatchedQueries/WatchedQueries.less";
 
 const mutationLabel = (mutationId, mutation) => {
-  const mutationName = getOperationName(mutation.mutation);
+  const mutationName = getOperationName(
+    // Apollo Client >= v2.5 includes `mutation.mutationString`. Versions prior
+    // include `mutation.mutation` which is an AST represetation of the
+    // mutation.
+    mutation.mutationString
+      ? parse(mutation.mutationString)
+      : mutation.mutation,
+  );
 
   if (!mutationName) {
     return mutationId;
@@ -184,7 +191,10 @@ class WatchedMutation extends React.Component {
       mutation.metadata.component.displayName;
     const displayName = componentDisplayName || reactComponentDisplayName;
 
-    const mutationString = print(mutation.mutation);
+    // Apollo Client >= v2.5 includes `mutation.mutationString`. Versions prior
+    // include `mutation.mutation` which is an AST represetation of the
+    // mutation.
+    const mutationString = mutation.mutationString || print(mutation.mutation);
 
     return (
       <div className={classnames("main", { loading: mutation.loading })}>


### PR DESCRIPTION
The mutations tab is broken because different versions of Apollo Client return different representations of the observed mutations. Prior to v2.5, `mutation.mutation` included an AST representation of the mutation body. With v2.5, `mutation.mutationString` is included instead. This will allow for both.

Resolves issue #182 	