### PR TITLE
Remove dependency on `localStorage` (and, by extension, 3rd party cookies)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Eliminate use of `window.localStorage` ([#118](https://github.com/apollographql/apollo-client-devtools/issues/118), [#142](https://github.com/apollographql/apollo-client-devtools/issues/142))
+  [@justinanastos](https://github.com/justinanastos) in [#185](https://github.com/apollographql/apollo-client-devtools/pull/185)
+
 ## 2.1.8
 
 - Fix mutations tab crashing devtools ([#182](https://github.com/apollographql/apollo-client-devtools/issues/182))

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ _Note: While great for expedited development of layout and CSS, this method does
 
 ### Debugging
 
-If the devtools panel is blank, it may be because you have third party cookies disabled. See [this stackoverflow](https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failted-to-read-localstorage-from-window-access-den) issue on how to enable them. This affects the devtools because they access `localStorage`, and that settings makes them throw an error when rendering.
-
 If there is an error in the devtools panel, you can inspect it just like you would inspect a normal webpage. Detach the inspector console from the window (if it's not already detached) by clicking the button with three vertical dots in the upper right corner of the console and selecting the detach option. With the detached console in focus, press `opt-cmd-I` again to open an inspector
 for the detached console (inspector inception). In this new inspector, you will be able to inspect elements in the first inspector, including the Apollo dev tools panel.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,13 +38,30 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.16",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.38.0"
+          }
+        }
       }
     },
     "acorn": {
@@ -52,23 +69,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
       "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
       "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "dev": true,
-      "requires": {
-        "acorn": "^4.0.3"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -670,9 +670,9 @@
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -687,6 +687,23 @@
       "dev": true,
       "requires": {
         "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
       }
     },
     "assert-plus": {
@@ -1153,9 +1170,9 @@
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
@@ -1553,9 +1570,9 @@
       }
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "base64url": {
@@ -1613,32 +1630,6 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
-    "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        }
-      }
-    },
     "bonjour": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
@@ -1654,9 +1645,9 @@
       },
       "dependencies": {
         "array-flatten": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+          "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
           "dev": true
         }
       }
@@ -1772,42 +1763,49 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "browserify-cipher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
-      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
         "evp_bytestokey": "^1.0.0"
-      },
-      "dependencies": {
-        "browserify-aes": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-          "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-          "dev": true,
-          "requires": {
-            "buffer-xor": "^1.0.3",
-            "cipher-base": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.3",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        }
       }
     },
     "browserify-des": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
-      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "browserify-rsa": {
@@ -1997,12 +1995,6 @@
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
       }
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -2644,8 +2636,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.0.7",
@@ -3407,7 +3398,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "~1.1.1",
         "entities": "~1.1.1"
@@ -3416,8 +3406,7 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -3430,8 +3419,7 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
       "version": "2.1.0",
@@ -3446,7 +3434,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -4323,6 +4310,24 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          }
+        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -7342,8 +7347,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
       "version": "1.2.0",
@@ -9992,8 +9996,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -10235,14 +10238,36 @@
       }
     },
     "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "react-apollo": {
@@ -10273,15 +10298,42 @@
       }
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
+      "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            }
+          }
+        }
       }
+    },
+    "react-is": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
+      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
     },
     "react-native-web": {
       "version": "0.3.2",
@@ -10333,7 +10385,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10806,8 +10857,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-json-stringify": {
       "version": "1.0.4",
@@ -10821,6 +10871,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
+      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "schema-utils": {
       "version": "0.4.3",
@@ -11748,7 +11807,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -12857,8 +12915,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utila": {
       "version": "0.4.0",
@@ -13204,6 +13261,23 @@
           "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
+        "acorn-dynamic-import": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+          "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+          "dev": true,
+          "requires": {
+            "acorn": "^4.0.3"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+              "dev": true
+            }
+          }
+        },
         "ajv": {
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -13233,6 +13307,12 @@
           "requires": {
             "pako": "~1.0.5"
           }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
         },
         "crypto-browserify": {
           "version": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "lodash.sortby": "^4.7.0",
     "lodash.uniqby": "^4.7.0",
     "prop-types": "^15.6.0",
-    "react": "^16.0.0",
+    "react": "^16.8.2",
     "react-apollo": "^2.1.0-beta.0",
-    "react-dom": "^16.0.0",
+    "react-dom": "^16.8.2",
     "uuid": "^3.0.1"
   }
 }

--- a/shells/dev/src/devtools.js
+++ b/shells/dev/src/devtools.js
@@ -1,5 +1,6 @@
 import { initDevTools } from "src/devtools";
 import Bridge from "src/bridge";
+import { createChromeStorageAdapter } from "./ChromeStorageAdapter";
 
 const target = document.getElementById("target");
 const targetWindow = target.contentWindow;
@@ -7,30 +8,33 @@ const targetWindow = target.contentWindow;
 // 1. load user app
 target.src = "target.html";
 target.onload = () => {
-  // 2. init devtools
-  initDevTools({
-    connect(cb) {
-      // 3. called by devtools: inject backend
-      inject("./dist/backend.js", () => {
-        // 4. send back bridge
-        cb(
-          new Bridge({
-            listen(fn) {
-              targetWindow.parent.addEventListener("message", evt =>
-                fn(evt.data),
-              );
-            },
-            send(data) {
-              console.log("devtools -> backend", data);
-              targetWindow.postMessage(data, "*");
-            },
-          }),
-        );
-      });
-    },
-    onReload(reloadFn) {
-      target.onload = reloadFn;
-    },
+  createChromeStorageAdapter(chrome.storage.local, chromeStorageAdapter => {
+    // 2. init devtools
+    initDevTools({
+      connect(cb) {
+        // 3. called by devtools: inject backend
+        inject("./dist/backend.js", () => {
+          // 4. send back bridge
+          cb(
+            new Bridge({
+              listen(fn) {
+                targetWindow.parent.addEventListener("message", evt =>
+                  fn(evt.data),
+                );
+              },
+              send(data) {
+                console.log("devtools -> backend", data);
+                targetWindow.postMessage(data, "*");
+              },
+            }),
+          );
+        });
+      },
+      onReload(reloadFn) {
+        target.onload = reloadFn;
+      },
+      storage: chromeStorageAdapter,
+    });
   });
 };
 

--- a/shells/webextension/manifest.json
+++ b/shells/webextension/manifest.json
@@ -11,7 +11,7 @@
   },
   "page_action": {},
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-  "permissions": ["tabs", "http://*/*", "https://*/*"],
+  "permissions": ["storage", "tabs", "http://*/*", "https://*/*"],
   "devtools_page": "devtools-background.html",
   "background": {
     "scripts": ["dist/background.js"],

--- a/shells/webextension/src/ChromeStorageAdapter.js
+++ b/shells/webextension/src/ChromeStorageAdapter.js
@@ -1,0 +1,96 @@
+// Expects a chrome.storage
+// [`StorageArea`](https://developer.chrome.com/apps/storage#type-StorageArea)
+// input and exports a
+// [Storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage) interface
+class ChromeStorageAdapter {
+  constructor(chromeStorage, readyCallback) {
+    if (!readyCallback) {
+      throw new TypeError(
+        "ChromeStorageAdapter called without a `readyCallback`",
+      );
+    }
+    this.chromeStorage = chromeStorage;
+
+    chromeStorage.get(
+      { apolloClientDevtools: {} },
+      ({ apolloClientDevtools }) => {
+        this.localCache = apolloClientDevtools;
+
+        readyCallback();
+      },
+    );
+  }
+
+  remoteWriteInFlight = false;
+  needsRemoteWrite = false;
+  localCache = {};
+
+  // This is the magic that connects chrome's `StorageArea` interface to the
+  // browser's `Storage` (ie localStorage).
+  //
+  // It's legal (and happens often) that we write multiple times _before_ the
+  // async write operation completes. Our goal is to make sure that writes are
+  // committed in order. When we write tests, this is what should be tested
+  // explicitly.
+  updateRemoteStorage = () => {
+    // If a write in progress then flag that we need a remote write and exit
+    // early.
+    if (this.remoteWriteInFlight) {
+      this.needsRemoteWrite = true;
+
+      return;
+    }
+
+    // Mark that a write is pending and that there is no data pending a write.
+    this.remoteWriteInFlight = true;
+    this.needsRemoteWrite = false;
+
+    // Save the current cache
+    this.chromeStorage.set({ apolloClientDevtools: this.localCache }, () => {
+      this.remoteWriteInFlight = false;
+
+      // If the `needsRemoteWrite` flag was set _while this async operation was
+      // in flight_, then we need to initiate another save.
+      if (this.needsRemoteWrite) {
+        this.updateRemoteStorage();
+      }
+    });
+  };
+
+  getItem = keyName => {
+    return this.localCache[keyName];
+  };
+
+  setItem = (keyName, value) => {
+    // Set the value locally and then async write to chrome.storage
+    this.localCache[keyName] = value;
+
+    this.updateRemoteStorage();
+  };
+
+  removeItem = keyName => {
+    delete this.localCache[keyName];
+
+    this.updateRemoteStorage();
+  };
+
+  clear = () => {
+    this.localCache = {};
+
+    this.updateRemoteStorage();
+  };
+}
+
+// We only export a factory function because we need to enforce the consumer
+// uses the `readyCallback`. We have to asynchronously read from the chrome
+// storage to prime the local cache, so this needs to use an async callback.
+export function createChromeStorageAdapter(storageArea, readyCallback) {
+  if (typeof readyCallback !== "function") {
+    throw new Error(
+      "You must pass a `readyCallback` function to `createChromeStorageAdapter`",
+    );
+  }
+  const chromeStorageAdapter = new ChromeStorageAdapter(storageArea, () =>
+    readyCallback(chromeStorageAdapter),
+  );
+}

--- a/shells/webextension/src/devtools.js
+++ b/shells/webextension/src/devtools.js
@@ -2,38 +2,43 @@
 // is activated
 import wat, { initDevTools } from "src/devtools";
 import Bridge from "src/bridge";
+import { createChromeStorageAdapter } from "./ChromeStorageAdapter";
 
-initDevTools({
-  connect(cb) {
-    // 1. inject backend code into page
-    injectScript(chrome.runtime.getURL("dist/backend.js"), () => {
-      // 2. connect to background to setup proxy
-      const port = chrome.runtime.connect({
-        name: "" + chrome.devtools.inspectedWindow.tabId,
-      });
-      let disconnected = false;
-      port.onDisconnect.addListener(() => {
-        disconnected = true;
-      });
+createChromeStorageAdapter(chrome.storage.local, storage => {
+  initDevTools({
+    connect(cb) {
+      // 1. inject backend code into page
+      injectScript(chrome.runtime.getURL("dist/backend.js"), () => {
+        // 2. connect to background to setup proxy
+        const port = chrome.runtime.connect({
+          name: "" + chrome.devtools.inspectedWindow.tabId,
+        });
+        let disconnected = false;
+        port.onDisconnect.addListener(() => {
+          disconnected = true;
+        });
 
-      const bridge = new Bridge({
-        listen(fn) {
-          port.onMessage.addListener(fn);
-        },
-        send(data) {
-          if (!disconnected) {
-            port.postMessage(data);
-          }
-        },
+        const bridge = new Bridge({
+          listen(fn) {
+            port.onMessage.addListener(fn);
+          },
+          send(data) {
+            if (!disconnected) {
+              port.postMessage(data);
+            }
+          },
+        });
+        // 3. send a proxy API to the panel
+        cb(bridge);
       });
-      // 3. send a proxy API to the panel
-      cb(bridge);
-    });
-  },
+    },
 
-  onReload(reloadFn) {
-    chrome.devtools.network.onNavigated.addListener(reloadFn);
-  },
+    onReload(reloadFn) {
+      chrome.devtools.network.onNavigated.addListener(reloadFn);
+    },
+
+    storage,
+  });
 });
 
 function injectScript(scriptName, cb) {

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -14,7 +14,7 @@ import {
 } from "graphql/utilities";
 import { mergeSchemas } from "graphql-tools";
 import { execute as graphql } from "graphql/execution";
-
+import { StorageContext } from "../../context/StorageContext";
 import { Observable, execute, ApolloLink } from "apollo-link";
 
 import { withBridge } from "../bridge";
@@ -137,6 +137,8 @@ export const createBridgeLink = bridge =>
   );
 
 export class Explorer extends Component {
+  static contextType = StorageContext;
+
   constructor(props, context) {
     super(props, context);
 
@@ -178,6 +180,7 @@ export class Explorer extends Component {
   render() {
     const { noFetch } = this.state;
     const { theme } = this.props;
+
     const graphiql = (
       <GraphiQL
         fetcher={this.fetcher}
@@ -189,6 +192,7 @@ export class Explorer extends Component {
         onEditVariables={() => {
           this.clearDefaultQueryState();
         }}
+        storage={this.context.storage}
         variables={this.state.variables}
         ref={r => {
           this.graphiql = r;

--- a/src/devtools/components/Sidebar.js
+++ b/src/devtools/components/Sidebar.js
@@ -1,7 +1,9 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-
+import { StorageContext } from "../context/StorageContext";
 export class Sidebar extends Component {
+  static contextType = StorageContext;
+
   constructor(props, context) {
     super(props, context);
 
@@ -11,7 +13,9 @@ export class Sidebar extends Component {
   }
 
   componentDidMount() {
-    const savedWidth = localStorage.getItem(`apollo-client:${this.props.name}`);
+    const savedWidth = this.context.storage.getItem(
+      `apollo-client:${this.props.name}`,
+    );
     if (savedWidth) this.sidebar.style.width = `${savedWidth}px`;
   }
 
@@ -22,7 +26,7 @@ export class Sidebar extends Component {
 
   Resize(e) {
     const width = e.clientX - this.sidebar.offsetLeft;
-    localStorage.setItem(`apollo-client:${this.props.name}`, width);
+    this.context.storage.setItem(`apollo-client:${this.props.name}`, width);
     this.sidebar.style.width = `${width}px`;
     window.getSelection().removeAllRanges();
   }

--- a/src/devtools/context/StorageContext.js
+++ b/src/devtools/context/StorageContext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const StorageContext = React.createContext({
+  storage: null,
+});

--- a/src/devtools/context/StorageContextProvider.js
+++ b/src/devtools/context/StorageContextProvider.js
@@ -1,0 +1,22 @@
+/* eslint-disable react/no-unused-state */
+import React from "react";
+import PropTypes from "prop-types";
+import { StorageContext } from "./StorageContext";
+
+export class StorageContextProvider extends React.PureComponent {
+  state = {
+    storage: this.props.storage,
+  };
+
+  render() {
+    return (
+      <StorageContext.Provider value={this.state}>
+        {this.props.children}
+      </StorageContext.Provider>
+    );
+  }
+}
+
+StorageContextProvider.propTypes = {
+  storage: PropTypes.object.isRequired,
+};

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { render } from "react-dom";
-
+import { StorageContextProvider } from "./context/StorageContextProvider";
 import Panel from "./components/Panel";
 import { BridgeProvider } from "./components/bridge";
 
@@ -15,11 +15,13 @@ export const initApp = shell => {
 
     const app = (
       <BridgeProvider bridge={bridge}>
-        <Panel
-          isChrome={isChrome}
-          bridge={bridge}
-          theme={isDark ? "dark" : "light"}
-        />
+        <StorageContextProvider storage={shell.storage}>
+          <Panel
+            isChrome={isChrome}
+            bridge={bridge}
+            theme={isDark ? "dark" : "light"}
+          />
+        </StorageContextProvider>
       </BridgeProvider>
     );
 


### PR DESCRIPTION
Chrome extensions will fail to access `window.localStorage` if 3rd party cookies are blocked. This extension uses `localStorage` in two places: in the sidebar and inside of GraphiQL.

This will replace the use of `window.localStorage` with a wrapper around [`chrome.storage.local`](https://chrome-apps-doc2.appspot.com/trunk/extensions/storage.html).

Yeah but how?

- Create an adapter between `chrome.storage` and `localStorage`.

    They have similar goals but are very different. `chrome.storage.local` uses async methods for getters and setters. `localStorage` uses sync methods. We'll keep a cached version of the local storage in memory and asynchronously sync that to chrome's storage. This removes the use of `localStorage` and the necessity of enabling 3rd party cookies. 

- Inject the storage into the application

- Share that storage throughout the application via context (so we can mock and test this later)

    Hence the React upgrade

- Consume the new storage via context

---

Resolves issue https://github.com/apollographql/apollo-client-devtools/issues/118

Hopefully contributes to issue https://github.com/apollographql/apollo-client-devtools/issues/142 🤞