### PR TITLE
Include local fields and types in GraphiQL

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Include local fields and types in GraphiQL ([#172](https://github.com/apollographql/apollo-client-devtools/issues/172), [#159](https://github.com/apollographql/apollo-client-devtools/issues/159))
+  [@justinanastos](https://github.com/justinanastos) in [#188](https://github.com/apollographql/apollo-client-devtools/pull/188)
+
 ## 2.1.9
 
 - Eliminate use of `window.localStorage`, removing the need for 3rd party cookies ([#118](https://github.com/apollographql/apollo-client-devtools/issues/118), [#142](https://github.com/apollographql/apollo-client-devtools/issues/142))

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -73,7 +73,8 @@ export const createBridgeLink = bridge =>
             buildSchema(`${directives} ${definition}`),
           );
           let directives = built.map(({ _directives }) => _directives);
-          let merged;
+
+          let mergedSchema;
 
           if (result.data && Object.keys(result.data).length !== 0) {
             // local and remote app
@@ -92,19 +93,19 @@ export const createBridgeLink = bridge =>
 
             directives = directives.concat(remoteSchema._directives);
 
-            merged = mergeSchemas({
+            mergedSchema = mergeSchemas({
               schemas: [remoteSchema].concat(built),
             });
           } else {
-            merged = mergeSchemas({ schemas: built });
+            mergedSchema = mergeSchemas({ schemas: built });
           }
 
-          merged._directives = uniqBy(
-            flatten(merged._directives.concat(directives)),
+          mergedSchema._directives = uniqBy(
+            flatten(mergedSchema._directives.concat(directives)),
             "name",
           );
           try {
-            const newResult = graphql(merged, introAST);
+            const newResult = graphql(mergedSchema, introAST);
             obs.next(newResult);
           } catch (e) {
             obs.error(e.stack);

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -74,7 +74,7 @@ export const createBridgeLink = bridge =>
           );
           let directives = built.map(({ _directives }) => _directives);
           let merged;
-          // local only app
+
           if (result.data && Object.keys(result.data).length !== 0) {
             // local and remote app
 


### PR DESCRIPTION
Resolves issue https://github.com/apollographql/apollo-client-devtools/issues/172 and https://github.com/apollographql/apollo-client-devtools/issues/159

Note: I've also tested this with The AC2.5 update (https://github.com/apollographql/apollo-client-devtools/pull/166); it works as advertised 🙆 

This does _not_ allow GraphiQL to differentiate between local and remote fields; they will look the same in the Documentation Explorer.