### PR TITLE
Update inspector.less

### DIFF
--- a/src/devtools/components/Inspector/inspector.less
+++ b/src/devtools/components/Inspector/inspector.less
@@ -111,6 +111,8 @@
   .inspector-body {
     flex: 1;
     display: flex;
+    /* bugfix: scroll does not work on chrome */
+    overflow: auto;
   }
 
   .inspector-sidebar {


### PR DESCRIPTION
to fix scroll bug on chrome Version 73.0.3683.86 (Official Build) (64-bit)