### PR TITLE
Integrate GraphiQL Explorer into devtools

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,9 @@
-# Changelog (started at 2.1.0)
+# Changelog
+
+## vNext
+
+- Integrate OneGraph's GraphiQL Explorer.  <br/>
+  [@sgrove](https://github.com/sgrove) in [#199](https://github.com/apollographql/apollo-client-devtools/pull/199)
 
 ## 2.2.1
 
@@ -97,3 +102,7 @@
 - initial local schema support (when using cache)
 - initial subscription support
 - improved dark theme
+
+# < 2.1.0
+
+- We didn't keep a changelog :-(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client-devtools",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4781,8 +4781,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -4833,8 +4832,7 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -4849,7 +4847,6 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -4858,7 +4855,6 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -4867,7 +4863,6 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -4876,8 +4871,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -4894,14 +4888,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -4909,26 +4901,22 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -4968,8 +4956,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -5001,8 +4988,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5024,14 +5010,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -5087,7 +5071,6 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -5100,8 +5083,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -5129,7 +5111,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -5140,8 +5121,7 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -5158,7 +5138,6 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -5167,8 +5146,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
@@ -5180,7 +5158,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5194,8 +5171,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -5268,14 +5244,12 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -5284,7 +5258,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5292,14 +5265,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5354,8 +5325,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -5373,7 +5343,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5403,8 +5372,7 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -5415,8 +5383,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -5454,7 +5421,6 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -5499,7 +5465,6 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -5507,8 +5472,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
@@ -5532,7 +5496,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -5566,7 +5529,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5577,7 +5539,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -5592,7 +5553,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5607,7 +5567,6 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -5663,8 +5622,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -5693,8 +5651,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5945,6 +5902,11 @@
         "codemirror-graphql": "^0.6.11",
         "markdown-it": "^8.4.0"
       }
+    },
+    "graphiql-explorer": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.3.7.tgz",
+      "integrity": "sha512-i24+xTe012/OAMFH/r9YL5QarSr/YqkP0Si0NspCnXKmJv7HzHueFUTRpFRPF1Ka9dLqiszrmOg/5stU4gCQnA=="
     },
     "graphql": {
       "version": "14.1.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "arson": "^0.2.5",
     "classnames": "^2.2.5",
     "graphiql": "^0.11.11",
+    "graphiql-explorer": "^0.3.7",
     "graphql": "^14.1.1",
     "graphql-syntax-highlighter-react": "^0.3.0",
     "graphql-tag": "^2.6.1",

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React, { Component } from "react";
 import GraphiQL from "graphiql";
 import GraphiQLExplorer from "graphiql-explorer";
@@ -8,7 +7,6 @@ import { parse } from "graphql/language/parser";
 import { print } from "graphql/language/printer";
 import {
   getIntrospectionQuery,
-  printIntrospectionSchema,
   buildSchema,
   introspectionQuery,
   printSchema,

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -184,7 +184,6 @@ export class Explorer extends Component {
       context: { noFetch: this.state.noFetch },
     });
 
-    console.log("fetcher result: ", result, typeof result);
     return result;
   };
 
@@ -227,8 +226,6 @@ export class Explorer extends Component {
     const { noFetch, query, schema } = this.state;
 
     const { theme } = this.props;
-
-    console.log("Contxt: ", this.context);
 
     const graphiql = (
       <div className="graphiql-container">

--- a/src/devtools/components/Explorer/graphiql-overrides.less
+++ b/src/devtools/components/Explorer/graphiql-overrides.less
@@ -10,6 +10,7 @@
     border-left-color: white;
   }
 }
+
 .graphiql-container {
   .CodeMirror pre {
     font-size: 12px;
@@ -76,6 +77,7 @@
       cursor: pointer;
       font-weight: normal;
       font-size: 12px;
+      line-height: 20px;
 
       input {
         margin: 0 5px 0 0;
@@ -178,5 +180,16 @@
       top: 33px;
       font-size: 12px;
     }
+  }
+
+  .history-title-bar {
+    height: auto;
+    padding: 0;
+    line-height: 13px;
+  }
+
+  .history-contents {
+    position: relative;
+    top: 0;
   }
 }


### PR DESCRIPTION
There are a few bugs that come from my confusion around [this](https://spectrum.chat/apollo/apollo-tooling/how-does-graphiql-in-the-apollo-client-devtools-have-access-to-the-schema~0026bf9f-444f-4ad4-abe7-017aa8d31213), but as a proof of concept it works perfectly fine. Mainly, the explorer won't get the schema until GraphiQL has loaded it up and there's been one state-invalidating thing to happen (e.g. typing in the query or clicking a button). If there's an easy way to get the schema in this component, it'd be a trivial swap.

The other concern is getting the current query text from the GraphiQL instance into the explorer - right now I store it in the state, but it could just as easily pull it from the editor state, just like the `prettify` action does.

Finally, I introduced a `getIn` helper to safely deal with deeply-nested attributes that might have nullable properties along the path, but it may not really be useful if there's an easier, more direct way to get the schema.

@jbaxleyiii Would be great to know what needs to change to actually get this to the right quality level and merged in!

Here's a demo video of using it in action: [![Apollo Client DevTools with the OneGraph GraphiQL Explorer](https://img.youtube.com/vi/95HOcvrFLHM/0.jpg)](https://youtu.be/95HOcvrFLHM)

