### PR TITLE
Gracefully handle checkVersions network error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,10 +6,12 @@
   [@sgrove](https://github.com/sgrove) in [#199](https://github.com/apollographql/apollo-client-devtools/pull/199)
 - Make sure devtools can be used when the transport layer is websockets
   only.  <br/>
-  [@kamerontanseli](https://github.com/kamerontanseli) in [#163](https://github.com/apollographql/apollo-client-devtools/pull/163) 
-- Debounce broadcast messages to improve devtools responsiveness and 
+  [@kamerontanseli](https://github.com/kamerontanseli) in [#163](https://github.com/apollographql/apollo-client-devtools/pull/163)
+- Debounce broadcast messages to improve devtools responsiveness and
   memory usage.  <br/>
   [@thomassuckow](https://github.com/thomassuckow) in [#173](https://github.com/apollographql/apollo-client-devtools/pull/173)
+- Gracefully handle a failed version compatibility check.  <br/>
+  [@mjlyons](https://github.com/mjlyons) in [#201](https://github.com/apollographql/apollo-client-devtools/pull/201)
 
 ## 2.2.1
 

--- a/src/backend/checkVersions.js
+++ b/src/backend/checkVersions.js
@@ -56,5 +56,8 @@ export const checkVersions = async (hook, bridge, storage) => {
           `console.info('Apollo devtools message:', "${cm.message}")`,
         );
       });
+    })
+    .catch(function() {
+      console.warn('Unable to check Apollo Dev Tools versions.')
     });
 };

--- a/src/backend/checkVersions.js
+++ b/src/backend/checkVersions.js
@@ -58,6 +58,6 @@ export const checkVersions = async (hook, bridge, storage) => {
       });
     })
     .catch(function() {
-      console.warn('Unable to check Apollo Dev Tools versions.')
+      console.warn("Unable to verify Apollo devtools version compatibility.");
     });
 };


### PR DESCRIPTION
Apollo Dev Tools is failing to initialize for me because my site's CSP settings block the checkVersions() request (to https://devtools.apollodata.com/graphql).

This change allows init() to proceed if the checkVersions network request fails.

I've verified that Apollo Dev Tools starts working with the patch by building the extension locally.