### PR TITLE
Increased timeout period for checking whether to display panel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
   [@thomassuckow](https://github.com/thomassuckow) in [#173](https://github.com/apollographql/apollo-client-devtools/pull/173)
 - Gracefully handle a failed version compatibility check.  <br/>
   [@mjlyons](https://github.com/mjlyons) in [#201](https://github.com/apollographql/apollo-client-devtools/pull/201)
+- Increase timeout when checking whether to display the devtools panel.  <br/>
+  [@Gongreg](https://github.com/Gongreg) in [#203](https://github.com/apollographql/apollo-client-devtools/pull/203)
 
 ## 2.2.1
 

--- a/shells/webextension/src/devtools-background.js
+++ b/shells/webextension/src/devtools-background.js
@@ -30,7 +30,7 @@ function onPanelHidden() {
 
 function createPanel() {
   // stop trying if above 10 seconds or already made
-  if (panelCreated || checkCount++ > 10) return;
+  if (panelCreated || checkCount++ > 120) return;
 
   panelLoaded = false;
   panelShown = false;

--- a/shells/webextension/src/devtools-background.js
+++ b/shells/webextension/src/devtools-background.js
@@ -29,7 +29,7 @@ function onPanelHidden() {
 }
 
 function createPanel() {
-  // stop trying if above 10 seconds or already made
+  // stop trying if above 120 seconds or already made
   if (panelCreated || checkCount++ > 120) return;
 
   panelLoaded = false;


### PR DESCRIPTION
A lot of users get confused in React Native when Apollo tab doesn't appear, since 10 seconds have already passed. I am increasing the timer by a lot so users would have enough time.