### PR TITLE
Detect devtools losing connection with apollo-client and reload

### DIFF
--- a/shells/webextension/src/backend.js
+++ b/shells/webextension/src/backend.js
@@ -38,6 +38,17 @@ function handshake(e) {
       listeners = [];
     });
 
+    bridge.on("backend:set-connection-nonce", data => {
+      const {connectionNonce} = JSON.parse(data);
+      window.adtConnectionNonce = connectionNonce;
+    });
+
+    bridge.on('backend:get-connection-nonce', () => {
+      const connectionNonce = window.adtConnectionNonce;
+      const jsonData = JSON.stringify({connectionNonce})
+      bridge.send('panel:connection-nonce', jsonData);
+    })
+
     // ensure that ApolloClient is ready before init
     let started = false;
     const init = () => {

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -8,10 +8,50 @@ import { BridgeProvider } from "./components/bridge";
 const isChrome = typeof chrome !== "undefined" && !!chrome.devtools;
 const isDark = isChrome ? chrome.devtools.panels.themeName === "dark" : false;
 
+const createNonce = () => Math.floor(Math.random() * 1073741824);
+
 export const initApp = shell => {
   shell.connect(bridge => {
     window.bridge = bridge;
     if (isChrome) chrome.runtime.sendMessage("apollo-panel-load");
+
+    const expectedConnectionNonce = createNonce();
+    const pendingJumpstarts = [];
+
+    bridge.on('ready', () => {
+      const data = JSON.stringify({connectionNonce: expectedConnectionNonce})
+      bridge.send('backend:set-connection-nonce', data)
+    })
+
+    // Ask backend (and apollo-client in main frame) which connectionNonce is active every two seconds
+    setInterval(() => {
+      bridge.send("backend:get-connection-nonce", JSON.stringify({expectedConnectionNonce}));
+      console.log(`sent backend:get-connection-nonce`);
+
+      // Reload extension pane if we don't get back the expected connectionNonce in a reasonable
+      // amount of time
+      const jumpstart = setTimeout(() => {
+        console.info('Apollo Client DevTools panel has lost heartbeat with apollo-client. Restarting panel.')
+        window.location.reload();
+      }, 5000)
+      pendingJumpstarts.push(jumpstart);
+      console.log(`Added pendingJumpstart`, pendingJumpstarts)
+    }, 2000)
+
+    // Check that apollo-client in main frame is using the current connectionNonce. If so,
+    // we have an active connection and everything is working. If not, the panel is trying
+    // to use an apollo-client that no longer exists (page was refreshed) and we should
+    // refresh the panel by letting jumpstart timeouts expire and cause a refresh.
+    bridge.on('panel:connection-nonce', data => {
+      const {connectionNonce} = JSON.parse(data);
+      if (connectionNonce === expectedConnectionNonce) {
+        while(pendingJumpstarts.length > 0) {
+          const jumpstart = pendingJumpstarts.pop();
+          clearTimeout(jumpstart);
+        }
+      }
+    })
+
 
     const app = (
       <BridgeProvider bridge={bridge}>


### PR DESCRIPTION
This PR is a little rough, but sending as a proposal on how to deal with page refreshes (Issue #108, @justinanastos). This resolves the issue for me.

As for what we might want to clean up:
- where we store the connectionNonce on the main frame from `window.adtConnectionNonce`
- defining timeouts as consts (and maybe tweaking the values)
- maybe some of this code belongs in different locations

Happy to make changes as requested (or feel free to make them yourself), assuming the rough approach works for ya'll.

Fixes https://github.com/apollographql/apollo-client-devtools/issues/108.