### PR TITLE
Fully reload devtools when a page reload happens

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@
   [@Gongreg](https://github.com/Gongreg) in [#203](https://github.com/apollographql/apollo-client-devtools/pull/203)
 - Fully reload devtools when a page reload happens, to make sure it is
   reconnected to the current Apollo Client instance properly.  <br/>
-  [@hwillson](https://github.com/hwillson) in [#TODO](https://github.com/apollographql/apollo-client-devtools/pull/TODO)
+  [@hwillson](https://github.com/hwillson) in [#205](https://github.com/apollographql/apollo-client-devtools/pull/205)
 
 ## 2.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@
   [@mjlyons](https://github.com/mjlyons) in [#201](https://github.com/apollographql/apollo-client-devtools/pull/201)
 - Increase timeout when checking whether to display the devtools panel.  <br/>
   [@Gongreg](https://github.com/Gongreg) in [#203](https://github.com/apollographql/apollo-client-devtools/pull/203)
+- Fully reload devtools when a page reload happens, to make sure it is
+  reconnected to the current Apollo Client instance properly.  <br/>
+  [@hwillson](https://github.com/hwillson) in [#TODO](https://github.com/apollographql/apollo-client-devtools/pull/TODO)
 
 ## 2.2.1
 

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -12,7 +12,6 @@ export const initApp = shell => {
   shell.connect(bridge => {
     window.bridge = bridge;
     if (isChrome) chrome.runtime.sendMessage("apollo-panel-load");
-
     const app = (
       <BridgeProvider bridge={bridge}>
         <StorageContextProvider storage={shell.storage}>
@@ -33,6 +32,6 @@ export const initDevTools = shell => {
   initApp(shell);
   shell.onReload(() => {
     bridge && bridge.removeAllListeners();
-    initApp(shell);
+    window.location.reload();
   });
 };


### PR DESCRIPTION
Right now when an application page reload is triggered, devtools becomes out of synch with the newly refreshed application. This means watched queries are no longer updated in the devtools panel, until the devtools are fully closed / re-opened. To keep the devtools in synch with the loaded application's Apollo Client instance, this PR reloads the devtools application if a page reload is triggered.

Fixes #108.