### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @justinanastos @cheapsteak


### PR DESCRIPTION
We've decided to stop using GH's code owners feature, since it doesn't really add any value, and unfortunately just adds a lot of noise to repo tracking. The current project maintainers are identified in the top level [`README.md`](https://github.com/apollographql/apollo-client-devtools/blob/master/README.md#maintainers).