### PR TITLE
Add npm publish to release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Release process, for those with permission:
 - Merge changes and version tag to `master`.
 - Run `npm run zip` to pack all of the builds for submission.
 - Create a new release on the webstores of each extension (and eventually cut a new electron release), uploading the new zip folder.
+- Make sure the version used in `manifest.json` is also used in `package.json`, and publish a new version to npm using `npm publish` in the root of the project.
 
 ### Prior Art
 


### PR DESCRIPTION
Whenever we publish a new version of the devtools for Chrome/FF, we need to also publish a new version to npm (so external tools integrating with devtools can get access to the latest version). We will want to automate this at some point in the future.