### PR TITLE
Filter __schema from Inspector

### DIFF
--- a/src/devtools/components/Inspector/Inspector.js
+++ b/src/devtools/components/Inspector/Inspector.js
@@ -273,6 +273,7 @@ class StoreTreeFieldSet extends React.Component {
   keysToDisplay() {
     return Object.keys(this.getStoreObj())
       .filter(key => key !== "__typename")
+      .filter(key => key !== "__schema")
       .sort();
   }
 


### PR DESCRIPTION
This pull request filters `__schema` items from the cache inspector.

### Why 
I found a situation where the Inspector panel would show the entire __schema object from cache.   ApolloClient was configured with additional typeDefs to be used for client side state.

In order to add UI state to our schema, we add `typeDefs` directly to our ApolloClient.  These typeDefs `extend type Query` which appears to cause an odd situation where the Inspector shows the __schema object the second (and subsequent) time the `ROOT_QUERY` is selected.

### Is this a bug?
I don't know that I would consider this a bug as its accurately displaying part of the cache.  However, when __schema is displayed in the cache inspector it makes it basically unusable.  The tools become slow and unresponsive and it's impossible to find the actual data you are looking for.

### Is this a fix?
It's *A* fix but I don't know that it's the right fix.  In the short term it has resolved my issue and allowed me to work.  I do not know the code well enough to know if there's a more appropriate fix that prevents the underlying situation from happening in the first place.
