### PR TITLE
Add Firefox extension to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apollo Client Devtools
 
-[Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) | (Download for Firefox temporarily disabled, it was removed from the Firefox store until the usage of `eval` is removed)
+[Download for Firefox](https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/) | [Download for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm)
 
 This repository contains the Apollo DevTools extension for Chrome & Firefox.
 
@@ -34,7 +34,7 @@ View the queries being actively watched on any given page. See when they're load
 
 # Installation
 
-You can install the extension via the [Chrome Webstore](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm).
+You can install the extension via [Firefox Browser Add-ons](https://addons.mozilla.org/en-US/firefox/addon/apollo-developer-tools/) or the [Chrome Webstore](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm).
 If you want to install a local version of the extension instead, skip ahead to the **Developing** section.
 
 ### Configuration


### PR DESCRIPTION
Apollo Client Devtools are back in Firefox 🎉

This PR updates the README to include the Firefox Browser Add-ons link.