### PR TITLE
Apollo Client 3 (@apollo/client) updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-client-devtools",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -4,6 +4,8 @@ import gql from "graphql-tag";
 
 import { buildSchemasFromTypeDefs } from "./typeDefs";
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 /*
  * Supports dynamic client schemas set on the context;
  * schemas must be an array of the following shape:
@@ -113,7 +115,7 @@ export const initLinkEvents = (hook, bridge) => {
       // is being used.
 
       const supportsApolloClientLocalState =
-        typeof apolloClient.typeDefs !== "undefined";
+        hasOwn.call(apolloClient, "typeDefs");
 
       if (!supportsApolloClientLocalState) {
         // Supports `apollo-link-state`.
@@ -193,7 +195,7 @@ export const initLinkEvents = (hook, bridge) => {
             // When using Apollo Client local state, we'll add the schema
             // manually.
             data.extensions = Object.assign({}, data.extensions, {
-              schemas: schemas.concat([apolloClientSchema]),
+              schemas: [apolloClientSchema],
             });
             bridge.send(`link:next:${key}`, JSON.stringify(data));
           },

--- a/src/devtools/components/Inspector/Inspector.js
+++ b/src/devtools/components/Inspector/Inspector.js
@@ -41,10 +41,12 @@ export default class Inspector extends React.Component {
     const sortedIdsWithoutRoot = unsortedIds
       .filter(id => id !== "ROOT_QUERY" && highlightedIds.indexOf(id) < 0)
       .sort();
+
     const ids =
-      sortedIdsWithoutRoot.length === 0
+      unsortedIds.length === 0
         ? []
         : [...highlightedIds, "ROOT_QUERY", ...sortedIdsWithoutRoot];
+
     const selectedId = this.state.selectedId || ids[0];
     this.setState({
       dataWithOptimistic,

--- a/src/devtools/components/Inspector/Inspector.js
+++ b/src/devtools/components/Inspector/Inspector.js
@@ -383,7 +383,19 @@ const StoreTreeObject = ({ value, highlight, inArray }) => {
     className += " inspector-highlight";
   }
 
-  return <span className={className}>{JSON.stringify(value)}</span>;
+  return (
+    <span className={className}>
+      {
+        value.__typename
+          ? (
+            <pre className="inspector-json">
+              {JSON.stringify(value, undefined, 2)}
+            </pre>
+          )
+          : JSON.stringify(value)
+      }
+    </span>
+  );
 };
 
 // props: data, value

--- a/src/devtools/components/Inspector/inspector.less
+++ b/src/devtools/components/Inspector/inspector.less
@@ -269,4 +269,8 @@
   .inspector-typename {
     color: #8b2bb9;
   }
+
+  .inspector-json {
+    margin: 0 0 0 1em;
+  }
 }


### PR DESCRIPTION
This PR updates devtools to be compatible with both Apollo Client 2 and 3. The commit messages go into more details, but there is one important thing to call out. Since we're working on a new version of devtools that is essentially a rewrite of the existing codebase, I've done the minimum necessary to get the existing devtools working with AC3. In most cases this is okay, but it does mean there are slight differences/limitations in the "Cache" panel. From https://github.com/apollographql/apollo-client-devtools/commit/5b256d6a8b45390597b24c9a7ff2c9d23fac2602: 

> We're working on a complete re-write of the AC devtools, so this
> commit should be considered temporary.
> 
> Apollo Client's internal cache structure has changed between
> AC2 and AC3. This means the `Inspector` code bits of devtools
> (that drive the Cache panel) are no longer compatible with the
> newer cache structure. The current `Inspector` relies on AC2's
> internal cache structure to render a hierarchical view of the
> cache, with links between different entities. Re-creating this
> for AC3 will take time away from our newer devtools rewrite
> work, so this commit focuses on making the minimal changes
> needed to get the Cache panel working with AC3.
> 
> With this commit, AC3 cache contents are displayed in the
> Cache panel, but contents are not properly linked (e.g. cache
> references are not followed and linked together). Nested
> entities are displayed as simple JSON dumps.

In other words, this is how the "Cache" panel looks/behaves when used with AC2:

![Image 2020-05-25 at 1 58 25 PM png](https://user-images.githubusercontent.com/137740/82834687-d2a8a100-9e8f-11ea-9b4b-0304efe167bb.png)

Whereas this is how it looks when used with AC3:

![Image 2020-05-25 at 1 59 16 PM png](https://user-images.githubusercontent.com/137740/82834723-ef44d900-9e8f-11ea-8f32-eb35bac7e653.png)

The AC3 version dumps a full representation of the cache contents, but it does not automatically link in referenced entities. The devtools rewrite we're working on will take care of all of this (and more), but hopefully this will serve as a stop gap until the new devtools are ready.

Fixes https://github.com/apollographql/apollo-client-devtools/issues/251.