### PR TITLE
Release 2.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0 (2020-05-28)
+
+- Support for Apollo Client 3 🎉 + fixes local state detection <br/> 
+  [@hwillson](https://github.com/hwillson) in [#263](https://github.com/apollographql/apollo-client-devtools/pull/263)
+
 ## 2.2.5 (2019-09-13)
 
 - More fixes for sidebar scrolling.  <br/>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the Apollo DevTools extension for Chrome & Firefox.
 
 If you are running Apollo Client 2.0, the dev tools require at least `apollo-client@2.0.0-rc.2` and `react-apollo@2.0.0-beta.0`, and you must be running at least version 2.0.5 of the dev tools themselves.
 
+If you are running Apollo Client 3.0, you must be running at least version 2.3.0 of the dev tools.
+
 The devtools no longer work with Apollo Client 1.0, but upgrading should be relatively easy! If it isn't, please reach out on the [Apollo Spectrum](https://spectrum.chat/apollo)
 
 ### Code of Conduct
@@ -97,6 +99,8 @@ If there is an error in the devtools panel, you can inspect it just like you wou
 for the detached console (inspector inception). In this new inspector, you will be able to inspect elements in the first inspector, including the Apollo dev tools panel.
 
 If you are using Apollo Client 2.0, make sure you are using at least version 2.0.5 of the devtools.
+
+If you are using Apollo Client 3.0, make sure you are using at least version 2.3.0 of the devtools.
 
 If you're seeing an error that's being caused by the devtools, please open an Issue on this repository with a detailed explanation of the problem and steps that we can take to replicate the error.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apollo-client-devtools",
   "description": "Developer tools for Apollo Client, with GraphiQL integration, cache inspection, and query watching.",
   "license": "MIT",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "scripts": {
     "build": "cd shells/webextension && cross-env NODE_ENV=production webpack --progress --hide-modules",
     "dev": "cd shells/dev && webpack-dev-server --inline --hot --no-info",

--- a/shells/webextension/manifest.json
+++ b/shells/webextension/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.5",
+  "version": "2.3.0",
   "author": "Apollo",
   "name": "Apollo Client Developer Tools",
   "short_name": "Apollo DevTools",


### PR DESCRIPTION
Prepping for the `2.3.0` release:

- Update the versioning
- Add changes to the changelog
- Update the README to note the use of `2.3.0` as a requirement to use the DevTools with Apollo Client 3