### PR TITLE
Do not save introspectionQuery results in the cache

### DIFF
--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -184,6 +184,7 @@ export const initLinkEvents = (hook, bridge) => {
         operationExecution$ = apolloClientReplica.watchQuery({
           query: queryAst,
           variables,
+          fetchPolicy,
         });
       }
 

--- a/src/devtools/components/Explorer/Explorer.js
+++ b/src/devtools/components/Explorer/Explorer.js
@@ -175,11 +175,11 @@ export class Explorer extends Component {
     this.link = createBridgeLink(this.props.bridge);
   }
 
-  fetcher = ({ query, variables = {} }) => {
+  fetcher = ({ query, variables = {}, noFetch = this.state.noFetch }) => {
     const result = execute(this.link, {
       query: parse(query),
       variables,
-      context: { noFetch: this.state.noFetch },
+      context: { noFetch },
     });
 
     return result;
@@ -188,6 +188,7 @@ export class Explorer extends Component {
   componentDidMount() {
     this.fetcher({
       query: getIntrospectionQuery(),
+      noFetch: false,
     }).forEach(result => {
       this.setState(oldState => {
         return {


### PR DESCRIPTION
Previously, we did not pass the fetchPolicy through to the cache replica, which results in the introspection query being saved to the cache. These queries could be large enough to slow down or crash the devtools.

Fixes https://github.com/apollographql/apollo-client-devtools/issues/271 and https://github.com/apollographql/apollo-client-devtools/issues/231.