### PR TITLE
Fix the local state functionality in the dev tools

### DIFF
--- a/src/backend/links.js
+++ b/src/backend/links.js
@@ -196,7 +196,7 @@ export const initLinkEvents = (hook, bridge) => {
             // When using Apollo Client local state, we'll add the schema
             // manually.
             data.extensions = Object.assign({}, data.extensions, {
-              schemas: [apolloClientSchema],
+              schemas: [...schemas, apolloClientSchema],
             });
             bridge.send(`link:next:${key}`, JSON.stringify(data));
           },


### PR DESCRIPTION
Since #263 the client-only schemas are not passed from the backend to the dev-tools anymore, which caused the dev-tools to not show any local-only schema information.

This PR is adding this back in, but using an immutable array as the previous version would append another `apolloClientSchema` copy to `schemas` each time `next` was called.


Test setup:
```typescript
import { ApolloClient, gql, InMemoryCache } from "@apollo/client";

const typeDefs = gql`
  extend type Query {
    testClientOnlyFiled: [String]
  }
`;

const cache = new InMemoryCache({
  typePolicies: {
    Query: {
      fields: {
        testClientOnlyFiled: {
          read() {
            return "TEST";
          },
        },
      },
    },
  },
});

export const apolloClient = new ApolloClient({
  uri: "https://graphqlzero.almansi.me/api",
  cache,
  typeDefs,
});
```

Before this change (expected `testClientOnlyFiled` to be in _Query_ and _Explorer_ panel):
<img width="1061" alt="Screenshot 2020-09-09 at 10 42 45 PM" src="https://user-images.githubusercontent.com/1680390/92675721-11068680-f2ee-11ea-996b-beff5295b2a0.png">

After this change (`testClientOnlyFiled` is in _Query_ and _Explorer_ panel):
<img width="1064" alt="Screenshot 2020-09-09 at 10 40 42 PM" src="https://user-images.githubusercontent.com/1680390/92675720-106df000-f2ee-11ea-8a0c-babcd856b4cd.png">
