### PR TITLE
Inspect mutations in the Mutations panel

### DIFF
--- a/src/application/Layouts/FullWidthLayout.tsx
+++ b/src/application/Layouts/FullWidthLayout.tsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
-import { useTheme } from "emotion-theming";
 import { rem } from "polished";
 import { Navigation, NavigationProps } from "./Navigation";
 

--- a/src/application/Layouts/SidebarLayout.tsx
+++ b/src/application/Layouts/SidebarLayout.tsx
@@ -29,6 +29,7 @@ const sidebarStyles = css`
   grid-area: sidebar;
   height: calc(100vh - ${rem(56)});
   padding: ${rem(16)};
+  overflow-y: scroll;
 `;
 
 const navigationStyles = css`

--- a/src/application/Mutations/MutationViewer.tsx
+++ b/src/application/Mutations/MutationViewer.tsx
@@ -1,0 +1,62 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { colors } from "@apollo/space-kit/colors";
+import { GraphqlCodeBlock } from "graphql-syntax-highlighter-react";
+import JSONTree from "react-json-tree";
+import { IconCopy } from "@apollo/space-kit/icons/IconCopy";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import stringifyObject from "stringify-object";
+import { 
+  queryViewStyles, 
+  headerStyles, 
+  copyIconStyle, 
+  queryStringHeader,
+  queryStringMain,
+  queryDataMain,
+} from '../Queries/QueryViewer';
+
+interface MutationViewerProps {
+  mutationString: string
+  variables: Record<string, any>
+}
+
+const queryDataHeader = css`
+  grid-area: queryDataHeader; 
+  display: flex;
+  height: 100%;
+  background-color: transparent;
+  ${headerStyles}
+  color: ${colors.black.base};
+
+  svg {
+    margin-right: 0;
+    margin-left: auto;
+  }
+`;
+
+export const MutationViewer = ({ mutationString = '', variables = {} }: MutationViewerProps) => (
+  <div css={queryViewStyles}>
+    <h4 css={queryStringHeader}>
+      Mutation String 
+      <CopyToClipboard text={mutationString}>
+        <IconCopy css={copyIconStyle} data-testid="copy-mutation-string" />
+      </CopyToClipboard> 
+    </h4>
+    <GraphqlCodeBlock
+      className="GraphqlCodeBlock"
+      css={queryStringMain}
+      queryBody={mutationString}
+    />
+    <div>
+      <div css={queryDataHeader}>
+        <span>Variables</span>
+        <CopyToClipboard text={stringifyObject(variables)}>
+          <IconCopy css={copyIconStyle} data-testid="copy-mutation-variables" />
+        </CopyToClipboard> 
+      </div>
+      <div css={queryDataMain}>
+        <JSONTree data={variables} />
+      </div>
+    </div>
+  </div>
+);

--- a/src/application/Mutations/Mutations.tsx
+++ b/src/application/Mutations/Mutations.tsx
@@ -1,16 +1,98 @@
-import React from "react";
-import { useQuery } from "@apollo/client";
+/** @jsx jsx */
+import { Fragment, useState } from "react";
+import { jsx } from "@emotion/core";
+import { useTheme } from "emotion-theming";
+import { gql, useQuery } from "@apollo/client";
+import { List } from "@apollo/space-kit/List";
+import { ListItem } from "@apollo/space-kit/ListItem";
+import { IconRun } from "@apollo/space-kit/icons/IconRun";
+import { Theme } from "../theme";
 import { SidebarLayout } from "../Layouts/SidebarLayout";
+import { 
+  sidebarHeadingStyles, 
+  h1Styles, 
+  operationNameStyles,
+  runButtonStyles,
+  listStyles,
+} from '../Queries/Queries';
+import { MutationViewer } from './MutationViewer';
+
+const GET_MUTATIONS = gql`
+  query GetMutations {
+    mutationLog @client {
+      mutations {
+        id
+        name
+      }
+    }
+  }
+`;
+
+const GET_SELECTED_MUTATION= gql`
+  query GetSelectedMutation($id: ID!) {
+    mutation(id: $id) @client {
+      id
+      name
+      mutationString
+      variables
+    }
+  }
+`;
 
 export const Mutations = ({ navigationProps }) => {
+  const [selected, setSelected] = useState<number>(0);
+  const theme = useTheme<Theme>();
+  const { data } = useQuery(GET_MUTATIONS);
+  const { data: selectedMutationData } = useQuery(GET_SELECTED_MUTATION, { 
+    variables: { id: selected },
+    returnPartialData: true,
+  });
 
   return (
     <SidebarLayout 
       navigationProps={navigationProps}
     >
-      <SidebarLayout.Sidebar>Mutations</SidebarLayout.Sidebar>
-      <SidebarLayout.Header>Mutations Header</SidebarLayout.Header>
-      <SidebarLayout.Main>Mutation Information</SidebarLayout.Main>
+      <SidebarLayout.Header>
+        {selectedMutationData?.mutation && (
+          <Fragment>
+            <h1 css={h1Styles}>{selectedMutationData?.mutation.name}</h1>
+            <span css={operationNameStyles}>Mutation</span>
+            <button css={runButtonStyles}>
+              <IconRun />
+              <span>Run in GraphiQL</span>
+            </button>
+          </Fragment>
+        )}
+      </SidebarLayout.Header>
+      <SidebarLayout.Sidebar>
+        <h3 css={sidebarHeadingStyles}>Mutations ({navigationProps.mutationsCount})</h3>
+        <List
+          css={listStyles}
+          selectedColor={theme.sidebarSelected}
+          hoverColor={theme.sidebarHover}
+        >
+          {data?.mutationLog?.mutations.map(({ name, id }) => {
+            return (
+              <ListItem 
+                key={`${name}-${id}`}
+                onClick={() => setSelected(id)}
+                selected={selected === id}
+              >
+                {name}
+              </ListItem>
+            );
+          })}
+        </List>
+      </SidebarLayout.Sidebar>
+      <SidebarLayout.Main>
+      {selectedMutationData?.mutation && (
+        <MutationViewer 
+          mutationString={selectedMutationData?.mutation?.mutationString}
+          variables={selectedMutationData?.mutation?.variables}
+        />
+      )}
+      </SidebarLayout.Main>
     </SidebarLayout>
   );
 };
+

--- a/src/application/Mutations/Mutations.tsx
+++ b/src/application/Mutations/Mutations.tsx
@@ -8,11 +8,11 @@ import { ListItem } from "@apollo/space-kit/ListItem";
 import { IconRun } from "@apollo/space-kit/icons/IconRun";
 import { Theme } from "../theme";
 import { SidebarLayout } from "../Layouts/SidebarLayout";
+import { RunInGraphiQLButton } from "../Queries/RunInGraphiQLButton";
 import { 
   sidebarHeadingStyles, 
   h1Styles, 
   operationNameStyles,
-  runButtonStyles,
   listStyles,
 } from '../Queries/Queries';
 import { MutationViewer } from './MutationViewer';
@@ -57,10 +57,9 @@ export const Mutations = ({ navigationProps }) => {
           <Fragment>
             <h1 css={h1Styles}>{selectedMutationData?.mutation.name}</h1>
             <span css={operationNameStyles}>Mutation</span>
-            <button css={runButtonStyles}>
-              <IconRun />
-              <span>Run in GraphiQL</span>
-            </button>
+            <RunInGraphiQLButton 
+              operation={selectedMutationData?.mutation?.mutationString}
+            />
           </Fragment>
         )}
       </SidebarLayout.Header>

--- a/src/application/Mutations/__tests__/MutationViewer.test.tsx
+++ b/src/application/Mutations/__tests__/MutationViewer.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { within } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import stringifyObject from "stringify-object";
+import { renderWithApolloClient } from '../../utilities/testing/renderWithApolloClient';
+import { MutationViewer } from '../MutationViewer';
+
+describe('<MutationViewer />', () => {
+  beforeEach(() => {
+    window.prompt = jest.fn();
+  });
+
+  const props = { 
+    mutationString: `
+      mutation AddColorToFavorites($color: ColorInput!) {
+        addColor(color: $color) {
+          ...colorFields
+        }
+      }
+      fragment colorFields on Color {
+        name
+        hex
+        contrast
+      }
+    `, 
+    variables: { 
+      name: 'Violet',
+      hex: '#15572C',
+      contrast: '#ffffff',
+    }, 
+  };
+
+  test('renders the mutation string', () => {
+    const { getByText, getAllByText } = renderWithApolloClient(
+      <MutationViewer {...props} />
+    );
+
+    expect(getByText('Mutation String')).toBeInTheDocument();
+    expect(getByText('AddColorToFavorites')).toBeInTheDocument();
+    expect(getAllByText('colorFields').length).toEqual(2);
+  });
+
+  test('can copy the mutation string', () => {
+    const { getByTestId } = renderWithApolloClient(
+      <MutationViewer {...props} />
+    );
+
+    const copyButton = getByTestId('copy-mutation-string');
+    user.click(copyButton);
+    expect(window.prompt).toBeCalledWith("Copy to clipboard: Ctrl+C, Enter", props.mutationString);
+  });
+
+  test('renders the mutation variables', () => {
+    const { getByText } = renderWithApolloClient(
+      <MutationViewer {...props} />
+    );
+
+    expect(getByText('Variables')).toBeInTheDocument();
+    expect(getByText(content => content.includes(props.variables.name))).toBeInTheDocument();
+  });
+
+  test('can copy the mutation variables', () => {
+    const { getByTestId } = renderWithApolloClient(
+      <MutationViewer {...props} />
+    );
+
+    const copyButton = getByTestId('copy-mutation-variables');
+    user.click(copyButton);
+    expect(window.prompt).toBeCalledWith("Copy to clipboard: Ctrl+C, Enter", stringifyObject(props.variables));
+  });
+});

--- a/src/application/Mutations/__tests__/MutationViewer.test.tsx
+++ b/src/application/Mutations/__tests__/MutationViewer.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { within } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import stringifyObject from "stringify-object";
 import { renderWithApolloClient } from '../../utilities/testing/renderWithApolloClient';

--- a/src/application/Mutations/__tests__/Mutations.test.tsx
+++ b/src/application/Mutations/__tests__/Mutations.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { within, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { renderWithApolloClient } from '../../utilities/testing/renderWithApolloClient';
+import { client, GET_MUTATIONS } from '../../index';
+import { Mutations } from '../Mutations';
+
+jest.mock('../MutationViewer', () => ({
+  MutationViewer: () => null, 
+}));
+
+describe('<Mutations />', () => {
+  const mutations = [
+    {
+      id: 0,
+      __typename: 'Mutation',
+      name: null,
+    },
+    {
+      id: 1,
+      __typename: 'Mutation',
+      name: 'AddColorToFavorites',
+    }
+  ];
+
+  const navigationProps = {
+    queriesCount: 0,
+    mutationsCount: 2,
+  };
+
+  test('queries render in the sidebar', async () => {
+    client.writeQuery({
+      query: GET_MUTATIONS,
+      data: {
+        mutationLog: {
+          mutations,
+          count: mutations.length,
+        },
+      },
+    });
+
+    const { getByTestId } = renderWithApolloClient(
+      <Mutations navigationProps={navigationProps} />
+    );
+
+    const sidebar = getByTestId('sidebar');
+    await waitFor(() => {
+      expect(within(sidebar).getByText(`Mutations (${navigationProps.mutationsCount})`)).toBeInTheDocument();
+      expect(within(sidebar).getByText('Unnamed')).toBeInTheDocument();
+      expect(within(sidebar).getByText('AddColorToFavorites')).toBeInTheDocument();
+    });
+  });
+
+  test('renders query name', async () => {
+    client.writeQuery({
+      query: GET_MUTATIONS,
+      data: {
+        mutationLog: {
+          mutations,
+          count: mutations.length,
+        },
+      },
+    });
+
+    const { getByTestId } = renderWithApolloClient(
+      <Mutations navigationProps={navigationProps} />
+    );
+
+    const header = getByTestId('header');
+    expect(within(header).getByText('Unnamed')).toBeInTheDocument();
+
+    const sidebar = getByTestId('sidebar');
+    user.click(within(sidebar).getByText('AddColorToFavorites'));
+    await waitFor(() => {
+      expect(within(header).getByText('AddColorToFavorites')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/application/Queries/Queries.tsx
+++ b/src/application/Queries/Queries.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { jsx, css } from "@emotion/core";
 import { useTheme } from "emotion-theming";
 import { rem } from "polished";
@@ -12,7 +12,7 @@ import { Theme } from "../theme";
 import { SidebarLayout } from "../Layouts/SidebarLayout";
 import { QueryViewer } from "./QueryViewer";
 
-const sidebarHeadingStyles = css`
+export const sidebarHeadingStyles = css`
   margin-left: ${rem(12)};
   text-transform: uppercase;
   font-size: ${rem(13)};
@@ -21,12 +21,12 @@ const sidebarHeadingStyles = css`
   color: rgba(255, 255, 255, .3);
 `;
 
-const h1Styles = css`
+export const h1Styles = css`
   font-family: monospace;
   font-weight: normal;
 `;
 
-const operationNameStyles = css`
+export const operationNameStyles = css`
   margin: ${rem(3)} 0 0 ${rem(8)};
   font-family: "Source Sans Pro", sans-serif;
   color: ${colors.grey.light};
@@ -34,7 +34,7 @@ const operationNameStyles = css`
   font-size: ${rem(13)};
 `;
 
-const runButtonStyles = css`
+export const runButtonStyles = css`
   appearance: none;
   display: flex;
   align-items: center;
@@ -50,7 +50,7 @@ const runButtonStyles = css`
   }
 `;
 
-const listStyles = css`
+export const listStyles = css`
   font-family: monospace;
   color: ${colors.silver.lighter};
 
@@ -97,12 +97,16 @@ export const Queries = ({ navigationProps }) => {
       navigationProps={navigationProps}
     >
       <SidebarLayout.Header>
-        <h1 css={h1Styles}>{watchedQueryData?.watchedQuery.name}</h1>
-        <span css={operationNameStyles}>Query</span>
-        <button css={runButtonStyles}>
-          <IconRun />
-          <span>Run in GraphiQL</span>
-        </button>
+        {watchedQueryData?.watchedQuery && (
+          <Fragment>
+            <h1 css={h1Styles}>{watchedQueryData?.watchedQuery.name}</h1>
+            <span css={operationNameStyles}>Query</span>
+            <button css={runButtonStyles}>
+              <IconRun />
+              <span>Run in GraphiQL</span>
+            </button>
+          </Fragment>
+        )}
       </SidebarLayout.Header>
       <SidebarLayout.Sidebar>
         <h3 css={sidebarHeadingStyles}>Active Queries ({navigationProps.queriesCount})</h3>
@@ -125,11 +129,13 @@ export const Queries = ({ navigationProps }) => {
         </List>
       </SidebarLayout.Sidebar>
       <SidebarLayout.Main>
+        {watchedQueryData?.watchedQuery && (
           <QueryViewer
             queryString={watchedQueryData?.watchedQuery.queryString}
             variables={watchedQueryData?.watchedQuery.variables}
             cachedData={watchedQueryData?.watchedQuery.cachedData}
           />
+        )}
       </SidebarLayout.Main>
     </SidebarLayout>
   );

--- a/src/application/Queries/Queries.tsx
+++ b/src/application/Queries/Queries.tsx
@@ -6,10 +6,10 @@ import { rem } from "polished";
 import { gql, useQuery } from "@apollo/client";
 import { List } from "@apollo/space-kit/List";
 import { ListItem } from "@apollo/space-kit/ListItem";
-import { IconRun } from "@apollo/space-kit/icons/IconRun";
 import { colors } from "@apollo/space-kit/colors";
 import { Theme } from "../theme";
 import { SidebarLayout } from "../Layouts/SidebarLayout";
+import { RunInGraphiQLButton } from "./RunInGraphiQLButton";
 import { QueryViewer } from "./QueryViewer";
 
 export const sidebarHeadingStyles = css`
@@ -32,22 +32,6 @@ export const operationNameStyles = css`
   color: ${colors.grey.light};
   text-transform: uppercase;
   font-size: ${rem(13)};
-`;
-
-export const runButtonStyles = css`
-  appearance: none;
-  display: flex;
-  align-items: center;
-  margin: 0 0 0 auto;
-  border: none;
-  font-size: ${rem(15)};
-  background-color: transparent;
-  cursor: pointer;
-
-  > svg {
-    width: ${rem(16)};
-    margin-right: ${rem(8)};
-  }
 `;
 
 export const listStyles = css`
@@ -101,10 +85,9 @@ export const Queries = ({ navigationProps }) => {
           <Fragment>
             <h1 css={h1Styles}>{watchedQueryData?.watchedQuery.name}</h1>
             <span css={operationNameStyles}>Query</span>
-            <button css={runButtonStyles}>
-              <IconRun />
-              <span>Run in GraphiQL</span>
-            </button>
+            <RunInGraphiQLButton 
+              operation={watchedQueryData?.watchedQuery.queryString} 
+            />
           </Fragment>
         )}
       </SidebarLayout.Header>

--- a/src/application/Queries/QueryViewer.tsx
+++ b/src/application/Queries/QueryViewer.tsx
@@ -11,9 +11,9 @@ import { IconCopy } from "@apollo/space-kit/icons/IconCopy";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import stringifyObject from "stringify-object";
 
-const queryViewStyles = css`
+export const queryViewStyles = css`
   display: grid;
-  grid-template-columns: minmax(${rem(600)}, auto) minmax(${rem(360)}, auto);
+  grid-template-columns: minmax(${rem(600)}, auto) ${rem(460)};
   grid-template-rows: ${rem(32)} auto;
   grid-column-gap: ${rem(24)};
   grid-template-areas:
@@ -22,13 +22,13 @@ const queryViewStyles = css`
   margin-top: ${rem(24)};
 `;
 
-const headerStyles = css`
+export const headerStyles = css`
   font-size: ${rem(16)};
   font-weight: 600;
   border-bottom: ${rem(1)} solid ${colors.silver.darker};
 `;
 
-const copyIconStyle = css`
+export const copyIconStyle = css`
   height: ${rem(16)};
   color: ${colors.silver.darker};
   cursor: pointer;
@@ -38,7 +38,7 @@ const copyIconStyle = css`
   }
 `;
 
-const queryStringHeader = css`
+export const queryStringHeader = css`
   grid-area: queryStringHeader; 
   display: flex;
   justify-content: space-between;
@@ -68,25 +68,35 @@ const queryDataHeader = css`
   }
 `;
 
-const queryStringMain = css`
+const calculatedHeight = `height: calc(100vh - ${rem(176)});`;
+export const queryStringMain = css`
   grid-area: queryStringMain;
+  ${calculatedHeight}
   margin-top: ${rem(24)};
   font-size: ${rem(15)};
+  overflow: scroll;
 `;
 
-const queryDataMain = css`
+export const queryDataMain = css`
   grid-area: queryDataMain;
+  ${calculatedHeight}
   margin-top: ${rem(24)};
   font-family: "Source Code Pro", monospace;
   font-size: ${rem(15)};
+  overflow: scroll;
 `;
+interface QueryViewerProps {
+  queryString: string
+  variables: Record<string, any>
+  cachedData: Record<string, any>
+} 
 
 enum QueryTabs {
   Variables,
   CachedData
 }
 
-export const QueryViewer = ({ queryString = '', variables = {}, cachedData = {} }) => {
+export const QueryViewer = ({ queryString = '', variables = {}, cachedData = {} }: QueryViewerProps) => {
   const [currentTab, setCurrentTab] = useState<QueryTabs>(QueryTabs.Variables);
   const copyCurrentTab = `${stringifyObject(currentTab === QueryTabs.Variables ? variables : cachedData)}`;
 

--- a/src/application/Queries/RunInGraphiQLButton.tsx
+++ b/src/application/Queries/RunInGraphiQLButton.tsx
@@ -1,0 +1,40 @@
+/** @jsx jsx */
+import { IconRun } from "@apollo/space-kit/icons/IconRun";
+import { jsx, css } from "@emotion/core";
+import { useTheme } from "emotion-theming";
+import { rem } from "polished";
+import { graphiQLQuery } from '../Explorer/Explorer';
+import { currentScreen, Screens } from "../Layouts/Navigation";
+
+interface RunInGraphiQLButtonProps {
+  operation: string;
+};
+
+export const buttonStyles = css`
+  appearance: none;
+  display: flex;
+  align-items: center;
+  margin: 0 0 0 auto;
+  border: none;
+  font-size: ${rem(15)};
+  background-color: transparent;
+  cursor: pointer;
+
+  > svg {
+    width: ${rem(16)};
+    margin-right: ${rem(8)};
+  }
+`;
+
+export const RunInGraphiQLButton = ({ operation }: RunInGraphiQLButtonProps) => (
+  <button 
+    css={buttonStyles}
+    onClick={() => {
+      graphiQLQuery(operation);
+      currentScreen(Screens.Explorer);
+    }}
+  >
+    <IconRun />
+    <span>Run in GraphiQL</span>
+  </button>
+);

--- a/src/application/Queries/__tests__/RunInGraphiQLButton.test.tsx
+++ b/src/application/Queries/__tests__/RunInGraphiQLButton.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { graphiQLQuery } from '../../Explorer/Explorer';
+import { currentScreen } from '../../Layouts/Navigation';
+import { RunInGraphiQLButton } from '../RunInGraphiQLButton';
+
+jest.mock('../../Explorer/Explorer', () => ({
+  graphiQLQuery: jest.fn(), 
+}));
+
+jest.mock('../../Layouts/Navigation', () => ({
+  currentScreen: jest.fn(), 
+  Screens: { Explorer: 'explorer'},
+}));
+
+describe('<RunInGraphiQLButton />', () => {
+  const props = {
+    operation: `
+      query GetSavedColors {
+        favoritedColors {
+          ...colorFields
+        }
+      }
+    
+      fragment colorFields on Color {
+        name
+        hex
+        contrast
+      }
+    `,
+  };
+
+  test('saves the operation and navigates to the Explorer panel', () => {
+    const { getByText } = render(
+      <RunInGraphiQLButton {...props} />
+    );
+    
+    const button = getByText('Run in GraphiQL');
+    expect(button).toBeInTheDocument();
+    user.click(button);
+    expect(graphiQLQuery).toHaveBeenCalledWith(props.operation);
+    expect(currentScreen).toHaveBeenCalledWith('explorer');
+  });
+});

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -44,10 +44,7 @@ const cache = new InMemoryCache({
         },
         cache() {
           return cacheVar();
-        },
-        graphiQLQuery() {
-          return graphiQLQuery();
-        },
+        }
       }
     }
   }
@@ -55,7 +52,6 @@ const cache = new InMemoryCache({
 
 const cacheVar = makeVar(null);
 export const colorTheme = makeVar<ColorTheme>(ColorTheme.Light);
-export const graphiQLQuery = makeVar<string>('');
 
 export const client = new ApolloClient({
   cache,
@@ -105,7 +101,7 @@ function getQueryData(query, key: number) {
 
 function getMutationData(mutation, key: number) {
   if (!mutation) return;
-  console.log(mutation);
+
   return {
     id: key,
     __typename: 'Mutation',

--- a/src/extension/devtools/panel.html
+++ b/src/extension/devtools/panel.html
@@ -6,16 +6,11 @@
     <style>
       html,
       body {
-        height: 100%;
-        width: 100%;
+        overflow: hidden;
       }
-      #container {
-        display: flex;
-        height: 100%;
-        width: 100%;
-      }
-      #app {
-        width: 100%;
+      #devtools {
+        width: 100vw;
+        height: 100vh;
       }
     </style>
     <link
@@ -28,8 +23,7 @@
     />
   </head>
   <body>
-    <div id="container">
-      <div id="app"></div>
+    <div id="devtools">
     </div>
     <script src="/panel.js"></script>
   </body>

--- a/src/extension/tab/tabRelay.ts
+++ b/src/extension/tab/tabRelay.ts
@@ -4,6 +4,7 @@ import {
   CREATE_DEVTOOLS_PANEL,
   ACTION_HOOK_FIRED,
   GRAPHIQL_RESPONSE,
+  UPDATE,
 } from '../constants';
 
 // Inspected tabs are unable to retrieve their own ids.
@@ -40,6 +41,7 @@ export default new Promise(async $export => {
 
   tab.forward(CREATE_DEVTOOLS_PANEL, `background:devtools-${id}`);
   tab.forward(ACTION_HOOK_FIRED, `background:devtools-${id}`);
+  tab.forward(UPDATE, `background:devtools-${id}`);
   tab.forward(GRAPHIQL_RESPONSE, `background:devtools-${id}:graphiql`);
 
   const module = await Promise.resolve({ tab, id });


### PR DESCRIPTION
Similar to #299, we can now inspect mutations in the Mutations panel! 

Users can:

- View the list of mutations
- Select a mutation to view its mutation string and variables
- Copy the mutation string or variables
- Use the Run in GraphiQL button to run the mutation (or query if on Queries) in Explorer

Some extra work was done to ensure overflowing sidebar, operation string, and operation data are scrollable.

<img width="1693" alt="Screen Shot 2020-11-05 at 4 11 06 PM" src="https://user-images.githubusercontent.com/5232812/98297050-d897c780-1f81-11eb-9476-237a3a7ffc15.png">
