### PR TITLE
Match Explorer to designs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       tag: 'current'
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          cache-path: ~/project/node_modules
+          override-ci-command: npx -p npm@6 npm ci
       - run:
           command: |
             npm run build
@@ -20,7 +22,9 @@ jobs:
       tag: 'current'
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          cache-path: ~/project/node_modules
+          override-ci-command: npx -p npm@6 npm ci
       - run:
           command: npm run test:circleci
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.2.tgz",
-      "integrity": "sha512-drgbagTptpo33EfOL9VedyOrPwx6u49vUdySAA3FMYRW5pSOtnWf5WMOC0fRp2xIGEtKAf0ZGC0DBbXbLvxiig==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.3.tgz",
+      "integrity": "sha512-zs148iUbBgmeQFOc+Jc4/Cb3LK7urQuCQGHifviMp0ihxzbJ8rtj0hCVuQhWaZxZRcL5oZBCfIuL1O5xuvszmQ==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.7.tgz",
-      "integrity": "sha512-4G80jvBLqenCFUhwkHAAHi2ox6Ygq35BkE38yxammqykZm6KE3tVlcEKGOZi0jpiuGJPC6LIQ0d1gtI8ADPtmg==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.9.tgz",
+      "integrity": "sha512-AUvYITKhJNfRNU/Cf8t/N628ADdVah1+l9Qtjd09IwScRfDGvbBTkHMAgcb6hl7vuBVqGwQRq6fPKzHgWRlisg==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
@@ -3864,6 +3864,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -5281,20 +5282,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "codemirror": {
-      "version": "5.58.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.3.tgz",
-      "integrity": "sha512-KBhB+juiyOOgn0AqtRmWyAT3yoElkuvWTI6hsHa9E6GQrl6bk/fdAYcvuqW1/upO9T9rtEtapWdw4XYcNiVDEA=="
-    },
-    "codemirror-graphql": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.12.3.tgz",
-      "integrity": "sha512-u0TooVA2MWGNV+Bio89RCTRW9P5FqegB1V9rnz9I0QKoGXX/c9z9/Fc+nj18p8jxkWK8ii8d7hkz7vsNsHxdkw==",
-      "requires": {
-        "graphql-language-service-interface": "^2.4.2",
-        "graphql-language-service-parser": "^1.6.4"
-      }
-    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -6521,11 +6508,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -7985,60 +7967,19 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
-    "graphiql": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-1.0.6.tgz",
-      "integrity": "sha512-PgKEfWkXxU4Lx92eSEcLF/2en5bjGplxNwwLCKEQ82xU7t8wfj4UL46Zwx40E9LcxJum6KRfGzMjcY+bNwHzpQ==",
-      "requires": {
-        "codemirror": "^5.54.0",
-        "codemirror-graphql": "^0.12.3",
-        "copy-to-clipboard": "^3.2.0",
-        "entities": "^2.0.0",
-        "markdown-it": "^10.0.0"
-      }
-    },
     "graphiql-explorer": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.6.2.tgz",
       "integrity": "sha512-hYSM+TI/0IAXltMOL7YXrvnA5xrKoDjjN7qiksxca2DY7yu46cyHVHG0IKIrBozMDBQLvFOhQMPrzplErwVZ1g=="
     },
+    "graphiql-forked": {
+      "version": "git+https://github.com/apollographql/graphiql.git#f81eb5614a1f1315c3ce3f764ef5b3dbff66db6e",
+      "from": "git+https://github.com/apollographql/graphiql.git"
+    },
     "graphql": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
       "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
-    },
-    "graphql-language-service-interface": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.4.2.tgz",
-      "integrity": "sha512-iFLMz51cA2L5Tu7/mP19++bRGUuIe2J9ekQZrcJ6sMYStsF60x5eNu3JqheduYTLhQaSdKN55jX7RlLeIDUhQA==",
-      "requires": {
-        "graphql-language-service-parser": "^1.6.4",
-        "graphql-language-service-types": "^1.6.3",
-        "graphql-language-service-utils": "^2.4.3",
-        "vscode-languageserver-types": "^3.15.1"
-      }
-    },
-    "graphql-language-service-parser": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.4.tgz",
-      "integrity": "sha512-Y365zUFfJ1GJ9NeRHb5Z/HBo6EnbuTi187Gkuldwd1YIDc0QcD7kqz6U5g043zd7BI/UZQth13Zd7pElvbb2zw==",
-      "requires": {
-        "graphql-language-service-types": "^1.6.3",
-        "typescript": "^3.9.5"
-      }
-    },
-    "graphql-language-service-types": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.3.tgz",
-      "integrity": "sha512-VDtBhdan1iSe7ad7+eBbsO5rrzWQpC6aV4SxSHEi8AtEQOFXpnL9Lq5jSaN8O02pGvAUr4wNUPu0oRU5g2XmVA=="
-    },
-    "graphql-language-service-utils": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.4.3.tgz",
-      "integrity": "sha512-XSCMKsV4GuVSGdW8RJTpO/IJDMXgESDJLu67SAuXFXwfel84j1gWrsmBAUeu6Di6NUEoM9NOCEtJv3LbU+/8qw==",
-      "requires": {
-        "graphql-language-service-types": "^1.6.3"
-      }
     },
     "graphql-syntax-highlighter-react": {
       "version": "0.4.0",
@@ -10566,14 +10507,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
-    "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10809,25 +10742,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
-        }
-      }
-    },
     "marky": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
@@ -10853,11 +10767,6 @@
       "requires": {
         "extend": "3.0.2"
       }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "mem": {
       "version": "5.1.1",
@@ -13833,7 +13742,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -14855,12 +14765,8 @@
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-    },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -15184,11 +15090,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
-    },
-    "vscode-languageserver-types": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,21 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.9.tgz",
-      "integrity": "sha512-AUvYITKhJNfRNU/Cf8t/N628ADdVah1+l9Qtjd09IwScRfDGvbBTkHMAgcb6hl7vuBVqGwQRq6fPKzHgWRlisg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.2.tgz",
+      "integrity": "sha512-drgbagTptpo33EfOL9VedyOrPwx6u49vUdySAA3FMYRW5pSOtnWf5WMOC0fRp2xIGEtKAf0ZGC0DBbXbLvxiig==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
+        "@wry/equality": "^0.3.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.0",
+        "optimism": "^0.13.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.5.0",
+        "ts-invariant": "^0.5.1",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
       }
@@ -2971,9 +2971,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.0.tgz",
+      "integrity": "sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:watch": "jest --watch",
     "zip": "npm run prezip && npm run zip:chrome && npm run zip:firefox",
     "zip:chrome": "zip -r -FS dist/chrome.zip build",
-    "zip:firefox": "web-ext build --source-dir build --artifacts-dir dist --overwrite-dest"
+    "zip:firefox": "web-ext build --source-dir build --artifacts-dir dist --overwrite-dest",
+    "postinstall": "cd node_modules/graphiql-forked/packages/graphiql && npm install --production"
   },
   "devDependencies": {
     "@babel/core": "^7.10.0",
@@ -72,8 +73,8 @@
     "@reach/tabs": "^0.11.2",
     "classnames": "^2.2.6",
     "emotion-theming": "^10.0.27",
-    "graphiql": "^1.0.3",
     "graphiql-explorer": "^0.6.2",
+    "graphiql-forked": "https://github.com/apollographql/graphiql",
     "graphql": "^15.3.0",
     "graphql-syntax-highlighter-react": "^0.4.0",
     "lodash.flattendeep": "^4.4.0",

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -51,8 +51,14 @@ const buttonContainerStyles = css`
 `;
 
 const buttonStyles = css`
+  font-weight: normal;
   font-size: ${rem(16)};
   color: ${colors.white};
+
+  &:hover {
+    background-color: ${colors.blilet.base};
+    color: ${colors.white};
+  }
 `;
 
 const runButtonStyles = css`
@@ -62,24 +68,27 @@ const runButtonStyles = css`
   border: none;
   border-radius: ${rem(4)};
   background-color: transparent;
+  cursor: pointer;
 
   svg {
     fill: currentColor;
   }
 
   &:hover {
-    background-color: ${colors.white};
-    color: ${colors.grey.base};
+    background-color: ${colors.blilet.base};
   }
 `;
 
 const docsButtonStyles = css`
+  ${buttonStyles}
   min-width: ${rem(60)};
   margin: 0 0 0 auto;
-  color: ${colors.white};
 `;
 
 const labelStyles = css`
+  display: inline-flex;
+  align-items: center;
+  margin: 0 0 0 ${rem(36)};
   font-size: ${rem(16)};
   color: ${colors.white};
 `;
@@ -88,12 +97,12 @@ const checkboxStyles = css`
   appearance: none;
   width: ${rem(20)};
   height: ${rem(20)};
-  margin: 0 ${rem(16)} 0 ${rem(36)};
+  margin-right: ${rem(16)};
   border-radius: ${rem(4)};
   background-color: ${colors.white};
 
   &:checked {
-    background-color: ${colors.blue.base};
+    background-color: ${colors.blilet.base};
   }
 `;
 
@@ -223,18 +232,18 @@ export const Explorer = ({ navigationProps }) => {
                     </Button>
                   </div>
                   <div css={borderStyles}></div>
-                  <input
-                    id="loadFromCache"
-                    css={checkboxStyles}
-                    type="checkbox"
-                    name="loadFromCache"
-                    checked={queryCache === FetchPolicy.CacheOnly}
-                    onChange={() => setQueryCache(queryCache === FetchPolicy.CacheOnly ? FetchPolicy.NoCache : FetchPolicy.CacheOnly)}
-                  />
                   <label 
                     htmlFor="loadFromCache"
                     css={labelStyles}
                   >
+                    <input
+                      id="loadFromCache"
+                      css={checkboxStyles}
+                      type="checkbox"
+                      name="loadFromCache"
+                      checked={queryCache === FetchPolicy.CacheOnly}
+                      onChange={() => setQueryCache(queryCache === FetchPolicy.CacheOnly ? FetchPolicy.NoCache : FetchPolicy.CacheOnly)}
+                    />
                     Load from cache
                   </label>
                   <Button

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -199,9 +199,9 @@ export const Explorer = ({ navigationProps }) => {
           query={query}
           editorTheme={color === ColorTheme.Dark ? 'dracula' : 'graphiql'}
           onEditQuery={newQuery => graphiQLQuery(newQuery)}
-          render={({ Logo, ExecuteButton, GraphiQLEditor, DocExplorer }) => {
+          render={({ ExecuteButton, GraphiQLEditor, DocExplorer }) => {
             return (
-              <Fragment>           
+              <Fragment>   
                 <FullWidthLayout.Header 
                   css={[
                     headerStyles, 

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -265,7 +265,7 @@ export const Explorer = ({ navigationProps }) => {
                     explorerIsOpen={isExplorerOpen}
                     onToggleExplorer={handleToggleExplorer}
                   />
-                  <GraphiQLEditor />
+                  {GraphiQLEditor}
                   {isDocsOpen && <DocExplorer onToggleDocs={handleToggleDocs} />}
                 </FullWidthLayout.Main>
               </Fragment>

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
+import { useTheme } from "emotion-theming";
 import { rem } from "polished";
 import { colors } from "@apollo/space-kit/colors";
 import { useRef, useState, useEffect, Fragment } from "react";
@@ -13,7 +14,7 @@ import { print } from "graphql/language/printer";
 import GraphiQLExplorer from "graphiql-explorer";
 import { Button } from "@apollo/space-kit/Button";
 import { colorTheme } from '../index';
-import { ColorTheme } from '../theme';
+import { ColorTheme, Theme } from '../theme';
 import { sendGraphiQLRequest, receiveGraphiQLResponses, listenForResponse } from './graphiQLRelay';
 import { FullWidthLayout } from '../Layouts/FullWidthLayout';
 
@@ -36,31 +37,64 @@ const headerStyles = css`
   display: flex;
   align-items: center;
   padding: 0 ${rem(16)};
-  border-bottom: ${rem(1)} solid ${colors.silver.darker};
+  border-bottom: ${rem(1)} solid;
+`;
+
+const mainStyles = css`
+  display: flex;
+`;
+
+const buttonContainerStyles = css`
+  display: inline-flex;
+  justify-content: space-around;
+  margin: 0 ${rem(16)};
 `;
 
 const buttonStyles = css`
-  margin: 0 ${rem(8)};
+  font-size: ${rem(16)};
+  color: ${colors.white};
 `;
 
 const runButtonStyles = css`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: ${rem(4)};
+  background-color: transparent;
 
+  svg {
+    fill: currentColor;
+  }
+
+  &:hover {
+    background-color: ${colors.white};
+    color: ${colors.grey.base};
+  }
 `;
 
 const docsButtonStyles = css`
+  min-width: ${rem(60)};
   margin: 0 0 0 auto;
+  color: ${colors.white};
 `;
 
 const labelStyles = css`
   font-size: ${rem(16)};
+  color: ${colors.white};
 `;
 
 const checkboxStyles = css`
   appearance: none;
   width: ${rem(20)};
   height: ${rem(20)};
-  margin-right: ${rem(8)};
-  border-radius: ${rem(3)};
+  margin: 0 ${rem(16)} 0 ${rem(36)};
+  border-radius: ${rem(4)};
+  background-color: ${colors.white};
+
+  &:checked {
+    background-color: ${colors.blue.base};
+  }
 `;
 
 const logoStyles = css`
@@ -69,6 +103,11 @@ const logoStyles = css`
   right: ${rem(16)};
 `;
 
+const borderStyles = css`
+  width: ${rem(1)};
+  height: ${rem(26)};
+  border-right: ${rem(1)} solid rgba(255, 255, 255, .3);
+`;
 
 export const Explorer = ({ navigationProps }) => {
   const graphiQLRef = useRef<GraphiQL>(null);
@@ -77,8 +116,10 @@ export const Explorer = ({ navigationProps }) => {
   const [isDocsOpen, setIsDocsOpen] = useState<boolean>(false);
   const [queryCache, setQueryCache] = useState<FetchPolicy>(FetchPolicy.NoCache);
 
-  const theme = useReactiveVar(colorTheme);
+  const color = useReactiveVar(colorTheme);
   const query = useReactiveVar(graphiQLQuery);
+
+  const theme = useTheme<Theme>();
 
   const executeOperation = ({ 
     query, 
@@ -127,7 +168,7 @@ export const Explorer = ({ navigationProps }) => {
   };
 
   const handleToggleExplorer = () => setIsExplorerOpen(!isExplorerOpen);
-  const handleToggleDocs = () => setIsDocsOpen(isDocsOpen);;
+  const handleToggleDocs = () => setIsDocsOpen(!isDocsOpen);;
 
   return (
     <FullWidthLayout 
@@ -147,27 +188,41 @@ export const Explorer = ({ navigationProps }) => {
           }) as any}
           schema={schema}
           query={query}
-          editorTheme={theme === ColorTheme.Dark ? 'dracula' : 'graphiql'}
+          editorTheme={color === ColorTheme.Dark ? 'dracula' : 'graphiql'}
           onEditQuery={newQuery => graphiQLQuery(newQuery)}
           render={({ Logo, ExecuteButton, GraphiQLEditor, DocExplorer }) => {
             return (
               <Fragment>           
-                <FullWidthLayout.Header css={headerStyles}>
-                  <ExecuteButton />
-                  <Button
-                    css={buttonStyles}
-                    title="Prettify"
-                    onClick={handleClickPrettifyButton}
-                  >
-                    Prettify
-                  </Button>
-                  <Button
-                    css={buttonStyles}
-                    title="Toggle Explorer"
-                    onClick={handleToggleExplorer}
-                  >
-                    Explorer
-                  </Button>
+                <FullWidthLayout.Header 
+                  css={[
+                    headerStyles, 
+                    { 
+                      backgroundColor: theme.primary,
+                      borderColor: theme.primary,
+                    }
+                  ]}
+                >
+                  <div css={borderStyles}></div>
+                  <div css={buttonContainerStyles}>
+                    <ExecuteButton css={[buttonStyles, runButtonStyles]} />
+                    <Button
+                      css={buttonStyles}
+                      title="Prettify"
+                      feel="flat"
+                      onClick={handleClickPrettifyButton}
+                    >
+                      Prettify
+                    </Button>
+                    <Button
+                      css={buttonStyles}
+                      title="Toggle Explorer"
+                      feel="flat"
+                      onClick={handleToggleExplorer}
+                    >
+                      Explorer
+                    </Button>
+                  </div>
+                  <div css={borderStyles}></div>
                   <input
                     id="loadFromCache"
                     css={checkboxStyles}
@@ -185,12 +240,15 @@ export const Explorer = ({ navigationProps }) => {
                   <Button
                     css={docsButtonStyles}
                     title="Open Document Explorer"
+                    feel="flat"
                     onClick={handleToggleDocs}
                   >
                     Docs
                   </Button>
                 </FullWidthLayout.Header>
-                <FullWidthLayout.Main>
+                <FullWidthLayout.Main
+                  css={mainStyles}
+                >
                   <GraphiQLExplorer
                     schema={schema}
                     query={query}
@@ -200,7 +258,6 @@ export const Explorer = ({ navigationProps }) => {
                   />
                   <GraphiQLEditor />
                   {isDocsOpen && <DocExplorer onToggleDocs={handleToggleDocs} />}
-                  <Logo css={logoStyles} />
                 </FullWidthLayout.Main>
               </Fragment>
             );

--- a/src/application/Explorer/__mocks__/@forked/graphiql.js
+++ b/src/application/Explorer/__mocks__/@forked/graphiql.js
@@ -1,0 +1,15 @@
+import React, { Component } from "react";
+
+const ExecuteButton = () => (<div>ExecuteButton</div>);
+const GraphiQLEditor = () => (<div>GraphiQLEditor</div>);
+const DocExplorer = () => (<div>DocExplorer</div>);
+
+export default class GraphiQL extends Component {
+  render() {
+    return this.props.render({
+      ExecuteButton,
+      GraphiQLEditor,
+      DocExplorer,
+    });
+  }
+}

--- a/src/application/Explorer/__tests__/Explorer.test.tsx
+++ b/src/application/Explorer/__tests__/Explorer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { within, waitForElementToBeRemoved } from '@testing-library/react';
+import { within, waitForElementToBeRemoved, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { renderWithApolloClient } from '../../utilities/testing/renderWithApolloClient';
 import { Explorer } from '../Explorer';
@@ -43,6 +43,7 @@ describe('<Explorer />', () => {
     expect(getByText('Prettify')).toBeInTheDocument();
     expect(getByText('Explorer')).toBeInTheDocument();
     expect(getByLabelText('Load from cache')).toBeInTheDocument();
+    expect(getByText('Docs')).toBeInTheDocument();
   });
 
   test('it can toggle the GraphiQLExplorer component', () => {
@@ -55,6 +56,17 @@ describe('<Explorer />', () => {
     expect(explorer).not.toBeVisible();
     user.click(button as HTMLElement);
     expect(explorer).toBeVisible();
+  });
+
+  test('it can toggle the DocExplorer component', () => {
+    const { getByTestId, getByText } = renderWithApolloClient(<Explorer navigationProps={navigationProps} />);
+    const header = getByTestId('header');
+    const { getByText: getByTextInHeader } = within(header);
+    const button = getByTextInHeader('Docs');
+
+    expect(screen.queryByText('DocExplorer')).not.toBeInTheDocument;
+    user.click(button as HTMLElement);
+    expect(screen.queryByText('DocExplorer')).toBeInTheDocument;
   });
 
   test('it retrieves a schema from an IntrospectionQuery', async () => {

--- a/src/application/Layouts/FullWidthLayout.tsx
+++ b/src/application/Layouts/FullWidthLayout.tsx
@@ -55,8 +55,8 @@ const FullWidthLayout: React.FC<FullWidthLayoutProps> & FullWidthLayoutCompositi
   );
 };
 
-const Header = ({ children }) => (<div css={headerStyles} data-testid="header">{children}</div>);
-const Main = ({ children }) => (<div css={mainStyles} data-testid="main">{children}</div>);
+const Header = ({ children, className }) => (<div className={className} css={headerStyles} data-testid="header">{children}</div>);
+const Main = ({ children, className }) => (<div css={mainStyles} data-testid="main">{children}</div>);
 
 FullWidthLayout.Header = Header;
 FullWidthLayout.Main = Main;

--- a/src/application/Layouts/FullWidthLayout.tsx
+++ b/src/application/Layouts/FullWidthLayout.tsx
@@ -6,6 +6,7 @@ import { Navigation, NavigationProps } from "./Navigation";
 interface FullWidthLayoutProps {
   navigationProps: NavigationProps
   children: any;
+  className?: string;
 };
 
 interface FullWidthLayoutComposition {
@@ -37,12 +38,14 @@ const headerStyles = css`
 const FullWidthLayout: React.FC<FullWidthLayoutProps> & FullWidthLayoutComposition = ({
   navigationProps,
   children,
+  className,
 }) => {
   const { queriesCount, mutationsCount } = navigationProps;
 
   return (
     <div 
       data-testid="layout" 
+      className={className}
       css={layoutStyles}
     >
       <Navigation
@@ -56,7 +59,7 @@ const FullWidthLayout: React.FC<FullWidthLayoutProps> & FullWidthLayoutCompositi
 };
 
 const Header = ({ children, className }) => (<div className={className} css={headerStyles} data-testid="header">{children}</div>);
-const Main = ({ children, className }) => (<div css={mainStyles} data-testid="main">{children}</div>);
+const Main = ({ children, className }) => (<div className={className} css={mainStyles} data-testid="main">{children}</div>);
 
 FullWidthLayout.Header = Header;
 FullWidthLayout.Main = Main;

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -200,15 +200,20 @@ export const App = () => {
   )
 };
 
-export const initDevTools = () => {
+const AppProvider = () => {
   const theme = useReactiveVar<ColorTheme>(colorTheme);
 
-  render(
+  return (
     <ApolloProvider client={client}>
       <ThemeProvider theme={themes[theme]}>
         <App />
       </ThemeProvider>
-    </ApolloProvider>,
+    </ApolloProvider>
+  );
+};
+
+export const initDevTools = () => {
+  render(<AppProvider />,
     document.getElementById("devtools")
   );
 };

--- a/src/application/theme.ts
+++ b/src/application/theme.ts
@@ -7,18 +7,18 @@ export enum ColorTheme {
 }
 
 const shared = {
-  sidebarSelected: colors.indigo.base,
+  sidebarSelected: colors.blilet.base,
 };
 
 export const themes: Record<ColorTheme, Record<string, ShadedColor>> = {
   [ColorTheme.Light]: {
-    primary: colors.indigo.darkest,
-    sidebarHover: lighten(0.2, colors.indigo.darkest) as ShadedColor,
+    primary: colors.blilet.darker,
+    sidebarHover: colors.blilet.darkest,
     ...shared,
   },
   [ColorTheme.Dark]: {
     primary: colors.black.base,
-    sidebarHover: lighten(0.2, colors.black.base) as ShadedColor,
+    sidebarHover: colors.midnight.darker,
     ...shared,
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,11 @@ module.exports = (env) => {
       filename: "[name].js",
     },
     resolve: {
-      extensions: [".mjs", ".js", ".ts", ".tsx"]
+      extensions: [".mjs", ".js", ".ts", ".tsx", ".css"],
+      alias: {
+        "@forked/graphiql": path.resolve(__dirname, "node_modules/graphiql-forked/packages/graphiql/dist/index.js"),
+        "@forked/graphiql-css": path.resolve(__dirname, "node_modules/graphiql-forked/packages/graphiql/graphiql.css")
+      }
     },
     module: {
       rules: [


### PR DESCRIPTION
We're using a [forked version of GraphiQL](https://github.com/apollographql/graphiql) to be able to use the UI components we need outside of the main <GraphiQL> component. Since those maintainers are working on version 2, it didn't make sense to request these changes for our own purposes. We'll revisit when GraphiQL 2.0 is available. 

Also, the color scheme has changed. I somehow missed these colors in Spacekit (how???) so now we're matching the designs.

Some remaining items for this section, to be done in a polish round:

- Add GraphiQL's logo for attribution
- A loading screen for when we're fetching the IntrospectionQuery

Future improvements might include:

- Ability to change the URL for the IntrospectionQuery
- Ability to retry the IntrospectionQuery