### PR TITLE
Hide introspection query

### DIFF
--- a/src/application/__tests__/AppProvider.test.tsx
+++ b/src/application/__tests__/AppProvider.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import matchMediaMock from '../utilities/testing/matchMedia';
 import { Mode } from '../theme';
-import { AppProvider, colorTheme } from '../index';
+import { AppProvider, colorTheme , getQueryData, getMutationData } from '../index';
 
 const matchMedia = matchMediaMock();
 
@@ -19,6 +19,97 @@ describe('<AppProvider />', () => {
     await waitFor(() => {
       matchMedia.useMediaQuery(Mode.Dark);
       expect(colorTheme()).toEqual('dark')
+    });
+  });
+
+  describe('getQueryData', () => {
+    let queryData;
+
+    beforeEach(() => {
+      queryData = {
+        document: {
+          definitions: [{ 
+            kind: 'OperationDefinition', 
+            name: {
+              value: 'GetColorByHex'
+            } 
+          }]
+        },
+        source: {
+          body: 'query-string'
+        },
+        variables: {
+          color: '#ee82ee'
+        },
+        cachedData: {
+          name: 'Violet'
+        },
+      };
+    });
+
+    test('returns expected query data', () => {
+      const data = getQueryData(queryData, 0);
+      expect(data).toEqual({
+        id: 0,
+        __typename: 'WatchedQuery',
+        name: 'GetColorByHex',
+        queryString: 'query-string',
+        variables: {
+          color: '#ee82ee'
+        },
+        cachedData: {
+          name: 'Violet'
+        },
+      });
+    });
+
+    test('ignores IntrospectionQuery', () => {
+      queryData.document = {
+        definitions: [{ 
+          kind: 'OperationDefinition', 
+          name: {
+            value: 'IntrospectionQuery'
+          } 
+        }]
+      };
+
+      const data = getQueryData(queryData, 0);
+      expect(data).toBeUndefined();
+    });
+  });
+  describe('getMutationData', () => {
+    let mutationData;
+    
+    beforeEach(() => {
+      mutationData = {
+        document: {
+          definitions: [{ 
+            kind: 'OperationDefinition', 
+            name: {
+              value: 'SaveColor'
+            } 
+          }],
+        },
+        source: {
+          body: 'mutation-string'
+        },
+        variables: {
+          color: '#ee82ee'
+        },
+      };
+    });
+
+    test('returns expected mutation data', () => {
+      const data = getMutationData(mutationData, 0);
+      expect(data).toEqual({
+        id: 0,
+        __typename: 'Mutation',
+        name: 'SaveColor',
+        mutationString: 'mutation-string',
+        variables: {
+          color: '#ee82ee'
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
The IntrospectionQuery is part of the setup for GraphiQL but we don't want it to show on the Queries panel. We now filter it out.