### PR TITLE
Fetch data every 500ms unless data is already enqueued

### DIFF
--- a/src/backend/broadcastQueries.js
+++ b/src/backend/broadcastQueries.js
@@ -86,16 +86,13 @@ export const initBroadCastEvents = (hook, bridge) => {
     }
   }
 
-  let logger = ({
-    _,
-    dataWithOptimisticResults: inspector,
-  }) => {
+  let logger = () => {
     counter++;
     enqueued = {
       counter,
       queries: queries(),
       mutations: mutations(),
-      inspector,
+      inspector: client.cache.extract(true),
     };
     if (acknowledged) {
       scheduleBroadcast();
@@ -107,6 +104,8 @@ export const initBroadCastEvents = (hook, bridge) => {
     acknowledged = true;
     if (enqueued) {
       scheduleBroadcast();
+    } else {
+      setTimeout(logger, 500);
     }
   });
 


### PR DESCRIPTION
Investigating #294 revealed that the cache doesn't update on longer-running requests. It works as expected for fast requests.   I've modified the hook to request data every 500ms (as long as an update is not enqueued). That seems to be working, so hopefully this fixes the issue.