### PR TITLE
Configurable object

### DIFF
--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "3.0.0",
+  "version_name": "3.0.0 beta",
   "author": "Apollo",
   "name": "Apollo Client Developer Tools",
   "short_name": "Apollo DevTools",
@@ -11,7 +12,7 @@
   },
   "page_action": {},
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-  "permissions": ["storage", "tabs", "http://*/*", "https://*/*"],
+  "permissions": ["http://*/*", "https://*/*"],
   "devtools_page": "devtools.html",
   "background": {
     "scripts": ["background.js"],

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -46,6 +46,7 @@ function initializeHook() {
     get() {
       return hook;
     },
+    configurable: true,
   });
 
   const clientRelay = new Relay();


### PR DESCRIPTION
For reasons unknown, we sometimes get this error: `Uncaught TypeError: Cannot redefine property: __APOLLO_DEVTOOLS_GLOBAL_HOOK__`

I'm suspicious that this happens when two Apollo Clients are running but this isn't confirmed. In the meanwhile, setting this to be configurable. This PR also removes unneeded permissions (storage and tabs).