### PR TITLE
guard against uninitialized client race condition

### DIFF
--- a/src/backend/broadcastQueries.js
+++ b/src/backend/broadcastQueries.js
@@ -87,6 +87,7 @@ export const initBroadCastEvents = (hook, bridge) => {
   }
 
   let logger = () => {
+    if (!client) return;
     counter++;
     enqueued = {
       counter,


### PR DESCRIPTION
with #321 there's a possibility of a race condition where the client had not been initialized yet but the logger function is getting called producing an error that looks like this:

```
Uncaught TypeError: Cannot read property 'cache' of null
    at ApolloClient.f [as devToolsHookCb] (backend.js:1)
    at QueryManager.onBroadcast (bundle.esm.js:2544)
    at QueryManager.broadcastQueries (bundle.esm.js:2001)
    at QueryManager.stopQuery (bundle.esm.js:1917)
    at ObservableQuery.tearDownQuery (bundle.esm.js:543)
    at eval (bundle.esm.js:473)
    at cleanupSubscription (Observable.js:107)
    at notifySubscription (Observable.js:168)
    at onNotify (Observable.js:195)
    at SubscriptionObserver.error (Observable.js:252)
```

I just added a guard to noop if the client has not been initialized yet. seems like there's probably a longer term fix that removes the race condition possibility in the first place, but that's beyond my understanding!