### PR TITLE
Replace EventTarget with simplified implementation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6923,11 +6923,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "event-to-promise": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/event-to-promise/-/event-to-promise-0.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@apollo/space-kit": "^7.21.0",
     "@emotion/core": "^10.0.35",
     "@reach/tabs": "^0.11.2",
-    "event-target-shim": "^5.0.1",
     "graphiql-explorer": "^0.6.2",
     "graphiql-forked": "https://github.com/apollographql/graphiql",
     "graphql": "^15.3.0",

--- a/src/Relay.ts
+++ b/src/Relay.ts
@@ -1,8 +1,8 @@
 /* 
   The native EventTarget interface is not useable in content scripts in Firefox. 
-  We import and extend from a shim to use the functionality we need.
+  We import and extend from this simplified class to use the EventTarget functionality we need.
 */
-import { EventTarget } from 'event-target-shim';
+import EventTarget from './extension/EventTarget';
 import { CustomEventListener, MessageObj } from './types';
 class Relay extends EventTarget {
   private connections = new Map<string, (event: CustomEvent<MessageObj>) => ReturnType<CustomEventListener>>();
@@ -26,11 +26,7 @@ class Relay extends EventTarget {
     }
   }
 
-  private dispatch(message: CustomEvent) {
-    this.dispatchEvent(message);
-  }
-
-  private createEvent(message: string) {
+  private createEvent = (message: string) => {
     return new CustomEvent(message, { detail: {} });
   }
 
@@ -58,7 +54,7 @@ class Relay extends EventTarget {
 
     event.detail['message'] = message.message;
     event.detail['payload'] = message.payload;
-    this.dispatch(event);
+    this.dispatchEvent(event);
   }
 
   public listen = <T = any>(name: string, fn: CustomEventListener<T>) => {

--- a/src/extension/EventTarget.ts
+++ b/src/extension/EventTarget.ts
@@ -1,0 +1,40 @@
+import { MessageObj } from '../types';
+
+export type EventListener<T = any> = (event: CustomEvent<MessageObj<T>>) => void;
+
+class EventTarget {
+  listeners = new Map<string, Set<EventListener>>();
+
+  addEventListener(eventType: string, callback: EventListener) {
+    const isRegistered = this.listeners.has(eventType);
+    
+    if (!isRegistered) {
+      this.listeners.set(eventType, new Set<EventListener>());
+    }
+
+    const listeners = this.listeners.get(eventType);
+    listeners.add(callback);
+  }
+
+  removeEventListener(eventType: string, callback) {
+    const isRegistered = this.listeners.has(eventType);
+
+    if (isRegistered) {
+      const listeners = this.listeners.get(eventType);
+      listeners.delete(callback);
+    }
+  }
+
+  dispatchEvent(event: CustomEvent<MessageObj>) {
+    const isRegistered = this.listeners.has(event?.type);
+
+    if (isRegistered) {
+      const listeners = this.listeners.get(event.type);
+      listeners.forEach(listener => listener(event));
+    }
+  }
+}
+
+export default EventTarget;
+
+

--- a/src/extension/EventTarget.ts
+++ b/src/extension/EventTarget.ts
@@ -13,7 +13,7 @@ class EventTarget {
     }
 
     const listeners = this.listeners.get(eventType);
-    listeners.add(callback);
+    listeners!.add(callback);
   }
 
   removeEventListener(eventType: string, callback) {
@@ -21,16 +21,16 @@ class EventTarget {
 
     if (isRegistered) {
       const listeners = this.listeners.get(eventType);
-      listeners.delete(callback);
+      listeners!.delete(callback);
     }
   }
 
-  dispatchEvent(event: CustomEvent<MessageObj>) {
+  dispatchEvent(event: CustomEvent) {
     const isRegistered = this.listeners.has(event?.type);
 
     if (isRegistered) {
       const listeners = this.listeners.get(event.type);
-      listeners.forEach(listener => listener(event));
+      listeners!.forEach(listener => listener(event));
     }
   }
 }

--- a/src/extension/__tests__/EventTargest.test.ts
+++ b/src/extension/__tests__/EventTargest.test.ts
@@ -1,0 +1,50 @@
+import EventTarget from '../EventTarget';
+
+describe('EventTarget', () => {
+  let eventTarget;
+  beforeEach(() => {
+    eventTarget = new EventTarget();
+  });
+
+  test('addEventListener', () => {
+    const cb = jest.fn();
+    eventTarget.addEventListener('test', cb);
+    const event = new CustomEvent('test');
+
+    eventTarget.dispatchEvent(event);
+    expect(cb).toHaveBeenCalledWith(event);
+  });
+
+  test('it handles multiple listeners', () => {
+    const cb1 = jest.fn();
+    eventTarget.addEventListener('test', cb1);
+
+    const cb2 = jest.fn();
+    eventTarget.addEventListener('test', cb2);
+
+    const event = new CustomEvent('test');
+    eventTarget.dispatchEvent(event);
+    expect(cb1).toHaveBeenCalledWith(event);
+    expect(cb2).toHaveBeenCalledWith(event);
+  });
+
+  test('it handles duplicate listeners', () => {
+    const cb1 = jest.fn();
+    eventTarget.addEventListener('test', cb1);
+    eventTarget.addEventListener('test', cb1);
+
+    const event = new CustomEvent('test');
+    eventTarget.dispatchEvent(event);
+    expect(cb1).toBeCalledTimes(1);
+  });
+
+  test('removeEventListener', () => {
+    const cb = jest.fn();
+    eventTarget.addEventListener('test', cb);
+    eventTarget.removeEventListener('test', cb);
+
+    const event = new CustomEvent('test');
+    eventTarget.dispatchEvent(event);
+    expect(cb).not.toHaveBeenCalledWith(event);
+  });
+});

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -72,9 +72,9 @@ function initializeHook() {
     sendMessageToTab(RELOADING_TAB);
   };
 
-  window.onload = () => {
+  window.addEventListener('load', () => {
     sendMessageToTab(RELOAD_TAB_COMPLETE, { ApolloClient: !!hook.ApolloClient });
-  };
+  });
 
   function handleActionHookForDevtools() {
     sendMessageToTab(ACTION_HOOK_FIRED);


### PR DESCRIPTION
As noted in #323, we replaced EventTarget with a shim due to an issue with EventTarget not dispatching events in the content script. The issue affected Firefox but not Chrome. That caused an unintentional issue noted in #328 that resulted in infinite looping on websites using Sentry. This PR replaced the shim with a simplified EventTarget implementation.