### PR TITLE
Empty states for Queries & Mutations panels

### DIFF
--- a/src/application/Mutations/Mutations.tsx
+++ b/src/application/Mutations/Mutations.tsx
@@ -46,7 +46,7 @@ export const Mutations = ({ navigationProps }) => {
     returnPartialData: true,
   });
 
-  const shouldRender = !!data?.mutationLog?.mutations.length;
+  const shouldRender = !!data?.mutationLog?.mutations?.length;
 
   return (
     <SidebarLayout 

--- a/src/application/Mutations/Mutations.tsx
+++ b/src/application/Mutations/Mutations.tsx
@@ -46,12 +46,14 @@ export const Mutations = ({ navigationProps }) => {
     returnPartialData: true,
   });
 
+  const shouldRender = !!data?.mutationLog?.mutations.length;
+
   return (
     <SidebarLayout 
       navigationProps={navigationProps}
     >
       <SidebarLayout.Header>
-        {selectedMutationData?.mutation && (
+        {shouldRender && (
           <Fragment>
             <h1 css={h1Styles}>{selectedMutationData?.mutation.name}</h1>
             <span css={operationNameStyles}>Mutation</span>
@@ -82,7 +84,7 @@ export const Mutations = ({ navigationProps }) => {
         </List>
       </SidebarLayout.Sidebar>
       <SidebarLayout.Main>
-      {selectedMutationData?.mutation && (
+      {shouldRender && (
         <MutationViewer 
           mutationString={selectedMutationData?.mutation?.mutationString}
           variables={selectedMutationData?.mutation?.variables}

--- a/src/application/Mutations/__tests__/Mutations.test.tsx
+++ b/src/application/Mutations/__tests__/Mutations.test.tsx
@@ -28,6 +28,10 @@ describe('<Mutations />', () => {
     mutationsCount: 2,
   };
 
+  beforeEach(() => {
+    client.clearStore();
+  });
+
   test('queries render in the sidebar', async () => {
     client.writeQuery({
       query: GET_MUTATIONS,
@@ -74,5 +78,14 @@ describe('<Mutations />', () => {
     await waitFor(() => {
       expect(within(header).getByText('AddColorToFavorites')).toBeInTheDocument();
     });
+  });
+
+  test('it renders an empty state', () => {
+    const { getByTestId } = renderWithApolloClient(
+      <Mutations navigationProps={navigationProps} />
+    );
+    
+    expect(getByTestId('header')).toBeEmptyDOMElement();
+    expect(getByTestId('main')).toBeEmptyDOMElement();
   });
 });

--- a/src/application/Queries/Queries.tsx
+++ b/src/application/Queries/Queries.tsx
@@ -75,7 +75,7 @@ export const Queries = ({ navigationProps }) => {
     returnPartialData: true,
   });
 
-  const shouldRender = !!data?.watchedQueries?.queries;
+  const shouldRender = !!data?.watchedQueries?.queries?.length;
   
   return (
     <SidebarLayout 

--- a/src/application/Queries/Queries.tsx
+++ b/src/application/Queries/Queries.tsx
@@ -74,13 +74,15 @@ export const Queries = ({ navigationProps }) => {
     variables: { id: selected },
     returnPartialData: true,
   });
+
+  const shouldRender = !!data?.watchedQueries?.queries;
   
   return (
     <SidebarLayout 
       navigationProps={navigationProps}
     >
       <SidebarLayout.Header>
-        {watchedQueryData?.watchedQuery && (
+        {shouldRender && (
           <Fragment>
             <h1 css={h1Styles}>{watchedQueryData?.watchedQuery.name}</h1>
             <span css={operationNameStyles}>Query</span>
@@ -111,7 +113,7 @@ export const Queries = ({ navigationProps }) => {
         </List>
       </SidebarLayout.Sidebar>
       <SidebarLayout.Main>
-        {watchedQueryData?.watchedQuery && (
+        {shouldRender && (
           <QueryViewer
             queryString={watchedQueryData?.watchedQuery.queryString}
             variables={watchedQueryData?.watchedQuery.variables}

--- a/src/application/Queries/__tests__/Queries.test.tsx
+++ b/src/application/Queries/__tests__/Queries.test.tsx
@@ -28,6 +28,10 @@ describe('<Queries />', () => {
     mutationsCount: 0,
   };
 
+  beforeEach(() => {
+    client.clearStore();
+  });
+
   test('queries render in the sidebar', async () => {
     client.writeQuery({
       query: GET_QUERIES,
@@ -74,5 +78,14 @@ describe('<Queries />', () => {
     await waitFor(() => {
       expect(within(header).getByText('GetColors')).toBeInTheDocument();
     });
+  });
+
+  test('it renders an empty state', () => {
+    const { getByTestId } = renderWithApolloClient(
+      <Queries navigationProps={navigationProps} />
+    );
+    
+    expect(getByTestId('header')).toBeEmptyDOMElement();
+    expect(getByTestId('main')).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
This PR changes the Queries & Mutation panels to show an empty state when no queries or mutations are present.