### PR TITLE
Various graphiql-explorer integration bug fixes and improvements

### DIFF
--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -51,14 +51,6 @@ const headerStyles = css`
 
 const mainStyles = css`
   display: flex;
-
-  .docExplorerWrap > .doc-explorer-title-bar > .doc-explorer-title {
-    font-size: 0;
-    &:after {
-      font-size: ${rem(16)};
-      content: "Build";
-    }
-  }
 `;
 
 const buttonContainerStyles = css`
@@ -101,7 +93,7 @@ const runButtonStyles = css`
 const docsButtonStyles = css`
   ${buttonStyles}
   min-width: ${rem(60)};
-  margin: 0 0 0 auto;
+  margin: 0 0 ${rem(2)} auto;
 `;
 
 const labelStyles = css`
@@ -130,12 +122,21 @@ const borderStyles = css`
 `;
 
 const explorerStyles = css`
-  .doc-explorer-title {
-    font-size: 0;
-    &:after {
-      font-size: ${rem(16)};
-      content: "Build";
-    }
+  .graphiql-explorer-root > div {
+    overflow: auto !important;
+  }
+
+  .graphiql-explorer-root > div > div {
+    outline: none;
+  }
+
+  .graphiql-operation-title-bar {
+    margin-top: ${rem(10)};
+  }
+
+  .docExplorerWrap {
+    box-shadow: none;
+    border-right: 1px solid #ddd;
   }
 `;
 
@@ -276,6 +277,7 @@ export const Explorer = ({ navigationProps }) => {
               <FullWidthLayout.Main css={mainStyles}>
                 <div css={explorerStyles}>
                   <GraphiQLExplorer
+                    title="Build"
                     schema={schema}
                     query={query}
                     onEdit={(newQuery) => graphiQLQuery(newQuery)}

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -71,6 +71,7 @@ const buttonStyles = css`
   font-weight: normal;
   font-size: ${rem(16)};
   color: ${colors.white};
+  margin-bottom: ${rem(2)};
 
   &:hover {
     background-color: ${colors.blilet.base};
@@ -86,6 +87,7 @@ const runButtonStyles = css`
   border-radius: ${rem(4)};
   background-color: transparent;
   cursor: pointer;
+  margin-bottom: 0;
 
   svg {
     fill: currentColor;
@@ -108,19 +110,11 @@ const labelStyles = css`
   margin: 0 0 0 ${rem(36)};
   font-size: ${rem(16)};
   color: ${colors.white};
+  line-height: ${rem(17)};
 `;
 
 const checkboxStyles = css`
-  appearance: none;
-  width: ${rem(20)};
-  height: ${rem(20)};
-  margin-right: ${rem(16)};
-  border-radius: ${rem(4)};
-  background-color: ${colors.white};
-
-  &:checked {
-    background-color: ${colors.blilet.base};
-  }
+  margin-right: ${rem(10)};
 `;
 
 const logoStyles = css`

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -5,29 +5,38 @@ import { colors } from "@apollo/space-kit/colors";
 import { useRef, useState, useEffect, Fragment } from "react";
 // @ts-ignore
 import GraphiQL from "@forked/graphiql";
-import { Observable, makeVar, useReactiveVar, FetchResult } from "@apollo/client";
+import {
+  Observable,
+  makeVar,
+  useReactiveVar,
+  FetchResult,
+} from "@apollo/client";
 import type { GraphQLSchema, IntrospectionQuery } from "graphql";
 import { getIntrospectionQuery, buildClientSchema } from "graphql/utilities";
 import { parse } from "graphql/language/parser";
 import { print } from "graphql/language/printer";
 import GraphiQLExplorer from "graphiql-explorer";
 import { Button } from "@apollo/space-kit/Button";
-import { useTheme, ColorTheme, colorTheme } from '../theme';
-import { sendGraphiQLRequest, receiveGraphiQLResponses, listenForResponse } from './graphiQLRelay';
-import { FullWidthLayout } from '../Layouts/FullWidthLayout';
+import { useTheme, ColorTheme, colorTheme } from "../theme";
+import {
+  sendGraphiQLRequest,
+  receiveGraphiQLResponses,
+  listenForResponse,
+} from "./graphiQLRelay";
+import { FullWidthLayout } from "../Layouts/FullWidthLayout";
 
 import "@forked/graphiql-css";
 
 enum FetchPolicy {
-  NoCache = 'no-cache',
-  CacheOnly = 'cache-only'
+  NoCache = "no-cache",
+  CacheOnly = "cache-only",
 }
 
-export const graphiQLQuery = makeVar<string>('');
+export const graphiQLQuery = makeVar<string>("");
 export const graphiQLSchema = makeVar<GraphQLSchema | undefined>(undefined);
 
 export const resetGraphiQLVars = () => {
-  graphiQLQuery('');
+  graphiQLQuery("");
   graphiQLSchema(undefined);
 };
 
@@ -42,6 +51,14 @@ const headerStyles = css`
 
 const mainStyles = css`
   display: flex;
+
+  .docExplorerWrap > .doc-explorer-title-bar > .doc-explorer-title {
+    font-size: 0;
+    &:after {
+      font-size: ${rem(16)};
+      content: "Build";
+    }
+  }
 `;
 
 const buttonContainerStyles = css`
@@ -118,37 +135,50 @@ const borderStyles = css`
   border-right: ${rem(1)} var(--whiteTransparent);
 `;
 
+const explorerStyles = css`
+  .doc-explorer-title {
+    font-size: 0;
+    &:after {
+      font-size: ${rem(16)};
+      content: "Build";
+    }
+  }
+`;
+
 export const Explorer = ({ navigationProps }) => {
   const graphiQLRef = useRef<GraphiQL>(null);
   const schema = useReactiveVar(graphiQLSchema);
   const [isExplorerOpen, setIsExplorerOpen] = useState<boolean>(false);
   const [isDocsOpen, setIsDocsOpen] = useState<boolean>(false);
-  const [queryCache, setQueryCache] = useState<FetchPolicy>(FetchPolicy.NoCache);
+  const [queryCache, setQueryCache] = useState<FetchPolicy>(
+    FetchPolicy.NoCache
+  );
 
   const color = useReactiveVar(colorTheme);
   const query = useReactiveVar(graphiQLQuery);
 
   const theme = useTheme();
 
-  const executeOperation = ({ 
-    query, 
-    operationName, 
-    variables, 
+  const executeOperation = ({
+    query,
+    operationName,
+    variables,
     fetchPolicy = queryCache,
-  }) => new Observable<FetchResult>(observer => {
-    const payload = JSON.stringify({
-      query,
-      operationName,
-      variables,
-      fetchPolicy,
-    });
+  }) =>
+    new Observable<FetchResult>((observer) => {
+      const payload = JSON.stringify({
+        query,
+        operationName,
+        variables,
+        fetchPolicy,
+      });
 
-    sendGraphiQLRequest(payload);
-    listenForResponse(operationName, payload => {
-      observer.next(payload);
-      observer.complete();
+      sendGraphiQLRequest(payload);
+      listenForResponse(operationName, (payload) => {
+        observer.next(payload);
+        observer.complete();
+      });
     });
-  });
 
   // Subscribe to GraphiQL data responses
   // Returns a cleanup method to useEffect
@@ -156,14 +186,14 @@ export const Explorer = ({ navigationProps }) => {
 
   useEffect(() => {
     if (!schema) {
-      const observer = executeOperation({ 
-        query: getIntrospectionQuery(), 
-        operationName: 'IntrospectionQuery', 
+      const observer = executeOperation({
+        query: getIntrospectionQuery(),
+        operationName: "IntrospectionQuery",
         variables: null,
-        fetchPolicy: FetchPolicy.NoCache, 
+        fetchPolicy: FetchPolicy.NoCache,
       });
-  
-      observer.subscribe(response => {
+
+      observer.subscribe((response) => {
         graphiQLSchema(buildClientSchema(response.data as IntrospectionQuery));
       });
     }
@@ -177,95 +207,95 @@ export const Explorer = ({ navigationProps }) => {
   };
 
   const handleToggleExplorer = () => setIsExplorerOpen(!isExplorerOpen);
-  const handleToggleDocs = () => setIsDocsOpen(!isDocsOpen);;
+  const handleToggleDocs = () => setIsDocsOpen(!isDocsOpen);
 
   return (
-    <FullWidthLayout 
-      navigationProps={navigationProps}
-    >
-
-        <GraphiQL
-          ref={graphiQLRef}
-          fetcher={(args => {
+    <FullWidthLayout navigationProps={navigationProps}>
+      <GraphiQL
+        ref={graphiQLRef}
+        fetcher={
+          ((args) => {
             // Ignore IntrospectionQuery from GraphiQL to prevent redundant introspections
             // We duplicate this call above so GraphiQLExplorer can access the schema
-            if (args.operationName === 'IntrospectionQuery') {
+            if (args.operationName === "IntrospectionQuery") {
               return Promise.resolve({});
             }
 
             return executeOperation(args);
-          }) as any}
-          schema={schema}
-          query={query}
-          editorTheme={color === ColorTheme.Dark ? 'dracula' : 'graphiql'}
-          onEditQuery={newQuery => graphiQLQuery(newQuery)}
-          render={({ ExecuteButton, GraphiQLEditor, DocExplorer }) => {
-            return (
-              <Fragment>   
-                <FullWidthLayout.Header 
-                  css={headerStyles}
-                >
-                  <div css={borderStyles}></div>
-                  <div css={buttonContainerStyles}>
-                    <ExecuteButton css={[buttonStyles, runButtonStyles]} />
-                    <Button
-                      css={buttonStyles}
-                      title="Prettify"
-                      feel="flat"
-                      onClick={handleClickPrettifyButton}
-                    >
-                      Prettify
-                    </Button>
-                    <Button
-                      css={buttonStyles}
-                      title="Toggle Explorer"
-                      feel="flat"
-                      onClick={handleToggleExplorer}
-                    >
-                      Explorer
-                    </Button>
-                  </div>
-                  <div css={borderStyles}></div>
-                  <label 
-                    htmlFor="loadFromCache"
-                    css={labelStyles}
-                  >
-                    <input
-                      id="loadFromCache"
-                      css={checkboxStyles}
-                      type="checkbox"
-                      name="loadFromCache"
-                      checked={queryCache === FetchPolicy.CacheOnly}
-                      onChange={() => setQueryCache(queryCache === FetchPolicy.CacheOnly ? FetchPolicy.NoCache : FetchPolicy.CacheOnly)}
-                    />
-                    Load from cache
-                  </label>
+          }) as any
+        }
+        schema={schema}
+        query={query}
+        editorTheme={color === ColorTheme.Dark ? "dracula" : "graphiql"}
+        onEditQuery={(newQuery) => graphiQLQuery(newQuery)}
+        render={({ ExecuteButton, GraphiQLEditor, DocExplorer }) => {
+          return (
+            <Fragment>
+              <FullWidthLayout.Header css={headerStyles}>
+                <div css={borderStyles}></div>
+                <div css={buttonContainerStyles}>
+                  <ExecuteButton css={[buttonStyles, runButtonStyles]} />
                   <Button
-                    css={docsButtonStyles}
-                    title="Open Document Explorer"
+                    css={buttonStyles}
+                    title="Prettify"
                     feel="flat"
-                    onClick={handleToggleDocs}
+                    onClick={handleClickPrettifyButton}
                   >
-                    Docs
+                    Prettify
                   </Button>
-                </FullWidthLayout.Header>
-                <FullWidthLayout.Main
-                  css={mainStyles}
+                  <Button
+                    css={buttonStyles}
+                    title="Toggle Explorer"
+                    feel="flat"
+                    onClick={handleToggleExplorer}
+                  >
+                    Build
+                  </Button>
+                </div>
+                <div css={borderStyles}></div>
+                <label htmlFor="loadFromCache" css={labelStyles}>
+                  <input
+                    id="loadFromCache"
+                    css={checkboxStyles}
+                    type="checkbox"
+                    name="loadFromCache"
+                    checked={queryCache === FetchPolicy.CacheOnly}
+                    onChange={() =>
+                      setQueryCache(
+                        queryCache === FetchPolicy.CacheOnly
+                          ? FetchPolicy.NoCache
+                          : FetchPolicy.CacheOnly
+                      )
+                    }
+                  />
+                  Load from cache
+                </label>
+                <Button
+                  css={docsButtonStyles}
+                  title="Open Document Explorer"
+                  feel="flat"
+                  onClick={handleToggleDocs}
                 >
+                  Docs
+                </Button>
+              </FullWidthLayout.Header>
+              <FullWidthLayout.Main css={mainStyles}>
+                <div css={explorerStyles}>
                   <GraphiQLExplorer
                     schema={schema}
                     query={query}
-                    onEdit={newQuery => graphiQLQuery(newQuery)}
+                    onEdit={(newQuery) => graphiQLQuery(newQuery)}
                     explorerIsOpen={isExplorerOpen}
                     onToggleExplorer={handleToggleExplorer}
                   />
-                  {GraphiQLEditor}
-                  {isDocsOpen && <DocExplorer onToggleDocs={handleToggleDocs} />}
-                </FullWidthLayout.Main>
-              </Fragment>
-            );
-          }}
-        />
+                </div>
+                {GraphiQLEditor}
+                {isDocsOpen && <DocExplorer onToggleDocs={handleToggleDocs} />}
+              </FullWidthLayout.Main>
+            </Fragment>
+          );
+        }}
+      />
     </FullWidthLayout>
   );
 };

--- a/src/application/Explorer/Explorer.tsx
+++ b/src/application/Explorer/Explorer.tsx
@@ -64,8 +64,11 @@ const buttonStyles = css`
   font-size: ${rem(16)};
   color: ${colors.white};
   margin-bottom: ${rem(2)};
+  margin-right: ${rem(10)};
 
-  &:hover {
+  &:hover,
+  &:active,
+  &:focus {
     background-color: ${colors.blilet.base};
     color: ${colors.white};
   }
@@ -132,13 +135,53 @@ const explorerStyles = css`
 
   .graphiql-operation-title-bar {
     margin-top: ${rem(10)};
+    line-height: ${rem(30)};
+    padding-bottom: 0 !important;
+
+    button {
+      outline: none;
+    }
+
+    input {
+      border: 1px solid rgb(221, 221, 221) !important;
+      box-shadow: none;
+      padding: 5px;
+      width: ${rem(200)} !important;
+    }
   }
 
   .docExplorerWrap {
     box-shadow: none;
     border-right: 1px solid #ddd;
   }
+
+  .graphiql-explorer-actions {
+    select {
+      margin-left: ${rem(5)};
+      outline: none;
+      border-color: #ccc;
+    }
+    button {
+      outline: none;
+    }
+  }
+
+  .toolbar-button {
+    height: 20px !important;
+    font-size: ${rem(20)};
+  }
 `;
+
+const explorerActionButtonStyles = {
+  actionButtonStyle: {
+    padding: `0 0 0 ${rem(5)}`,
+    margin: 0,
+    backgroundColor: "white",
+    border: "none",
+    fontSize: rem(20),
+    display: "inline-block",
+  },
+};
 
 export const Explorer = ({ navigationProps }) => {
   const graphiQLRef = useRef<GraphiQL>(null);
@@ -280,9 +323,25 @@ export const Explorer = ({ navigationProps }) => {
                     title="Build"
                     schema={schema}
                     query={query}
-                    onEdit={(newQuery) => graphiQLQuery(newQuery)}
+                    onEdit={(newQuery) => {
+                      // Before passing a query to graphiql to be run, we'll
+                      // make sure it doesn't include an empty top level
+                      // selection set. If it does and graphiql tries to run
+                      // it, graphiql-explorer (3rd party plugin) functionality
+                      // will break. This means new graphiql-explorer
+                      // started queries will always be valid queries, including
+                      // `__typename` at a minimum.
+                      const queryWithoutNewlines = newQuery.replace("\n", "");
+                      const cleanQuery =
+                        !!queryWithoutNewlines &&
+                        !queryWithoutNewlines.includes("{")
+                          ? `${queryWithoutNewlines} {\n  __typename\n}`
+                          : newQuery;
+                      graphiQLQuery(cleanQuery);
+                    }}
                     explorerIsOpen={isExplorerOpen}
                     onToggleExplorer={handleToggleExplorer}
+                    styles={explorerActionButtonStyles}
                   />
                 </div>
                 {GraphiQLEditor}

--- a/src/application/Explorer/__tests__/Explorer.test.tsx
+++ b/src/application/Explorer/__tests__/Explorer.test.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { within, waitForElementToBeRemoved, screen } from '@testing-library/react';
-import user from '@testing-library/user-event';
-import { renderWithApolloClient } from '../../utilities/testing/renderWithApolloClient';
-import { Explorer } from '../Explorer';
-import { listenForResponse } from '../graphiQLRelay';
+import React from "react";
+import {
+  within,
+  waitForElementToBeRemoved,
+  screen,
+} from "@testing-library/react";
+import user from "@testing-library/user-event";
+import { renderWithApolloClient } from "../../utilities/testing/renderWithApolloClient";
+import { Explorer } from "../Explorer";
+import { listenForResponse } from "../graphiQLRelay";
 
-import { graphql } from 'graphql';
+import { graphql } from "graphql";
 import { getIntrospectionQuery } from "graphql/utilities";
-import { schemaWithMocks } from '../../utilities/testing/fakeGraphQL';
+import { schemaWithMocks } from "../../utilities/testing/fakeGraphQL";
 
 // Required to prevent an error in CodeMirror
 document.createRange = () => {
@@ -19,67 +23,75 @@ document.createRange = () => {
     return {
       item: () => null,
       length: 0,
-      [Symbol.iterator]: jest.fn()
+      [Symbol.iterator]: jest.fn(),
     };
   };
 
   return range;
-}
+};
 
-jest.mock('../graphiQLRelay', () => ({
-  sendGraphiQLRequest: jest.fn(), 
-  receiveGraphiQLResponses: jest.fn(), 
+jest.mock("../graphiQLRelay", () => ({
+  sendGraphiQLRequest: jest.fn(),
+  receiveGraphiQLResponses: jest.fn(),
   listenForResponse: jest.fn(),
 }));
 
-describe('<Explorer />', () => {
+describe("<Explorer />", () => {
   const navigationProps = { queriesCount: 0, mutationsCount: 0 };
-  test('it renders a header', () => {
-    const { getByTestId } = renderWithApolloClient(<Explorer navigationProps={navigationProps} />);
-    const header = getByTestId('header');
+  test("it renders a header", () => {
+    const { getByTestId } = renderWithApolloClient(
+      <Explorer navigationProps={navigationProps} />
+    );
+    const header = getByTestId("header");
     const { getByText, getByLabelText } = within(header);
-  
+
     expect(header).toBeInTheDocument();
-    expect(getByText('Prettify')).toBeInTheDocument();
-    expect(getByText('Explorer')).toBeInTheDocument();
-    expect(getByLabelText('Load from cache')).toBeInTheDocument();
-    expect(getByText('Docs')).toBeInTheDocument();
+    expect(getByText("Prettify")).toBeInTheDocument();
+    expect(getByText("Build")).toBeInTheDocument();
+    expect(getByLabelText("Load from cache")).toBeInTheDocument();
+    expect(getByText("Docs")).toBeInTheDocument();
   });
 
-  test('it can toggle the GraphiQLExplorer component', () => {
-    const { container, getByTestId } = renderWithApolloClient(<Explorer navigationProps={navigationProps} />);
-    const header = getByTestId('header');
+  test("it can toggle the GraphiQLExplorer component", () => {
+    const { container, getByTestId } = renderWithApolloClient(
+      <Explorer navigationProps={navigationProps} />
+    );
+    const header = getByTestId("header");
     const { getByText } = within(header);
 
-    const button = getByText('Explorer');
-    const explorer = container.querySelector('.docExplorerWrap');
+    const button = getByText("Build");
+    const explorer = container.querySelector(".docExplorerWrap");
     expect(explorer).not.toBeVisible();
     user.click(button as HTMLElement);
     expect(explorer).toBeVisible();
   });
 
-  test('it can toggle the DocExplorer component', () => {
-    const { getByTestId } = renderWithApolloClient(<Explorer navigationProps={navigationProps} />);
-    const header = getByTestId('header');
+  test("it can toggle the DocExplorer component", () => {
+    const { getByTestId } = renderWithApolloClient(
+      <Explorer navigationProps={navigationProps} />
+    );
+    const header = getByTestId("header");
     const { getByText: getByTextInHeader } = within(header);
-    const button = getByTextInHeader('Docs');
+    const button = getByTextInHeader("Docs");
 
-    expect(screen.queryByText('DocExplorer')).not.toBeInTheDocument;
+    expect(screen.queryByText("DocExplorer")).not.toBeInTheDocument;
     user.click(button as HTMLElement);
-    expect(screen.queryByText('DocExplorer')).toBeInTheDocument;
+    expect(screen.queryByText("DocExplorer")).toBeInTheDocument;
   });
 
-  test('it retrieves a schema from an IntrospectionQuery', async () => {
-    (listenForResponse as any).mockImplementation(((_, cb) => {
-      graphql(schemaWithMocks, getIntrospectionQuery()).then((result) => cb(result));
-    }), );
+  test("it retrieves a schema from an IntrospectionQuery", async () => {
+    (listenForResponse as any).mockImplementation((_, cb) => {
+      graphql(schemaWithMocks, getIntrospectionQuery()).then((result) =>
+        cb(result)
+      );
+    });
 
-    const { getByText } = renderWithApolloClient(<Explorer navigationProps={navigationProps} />);
-    const NoSchemaError = getByText('No Schema Available');
+    const { getByText } = renderWithApolloClient(
+      <Explorer navigationProps={navigationProps} />
+    );
+    const NoSchemaError = getByText("No Schema Available");
     expect(NoSchemaError).toBeInTheDocument();
 
     waitForElementToBeRemoved(NoSchemaError);
   });
 });
-
-

--- a/src/application/Layouts/Navigation.tsx
+++ b/src/application/Layouts/Navigation.tsx
@@ -39,7 +39,7 @@ const navButtonStyles = css`
   appearance: none;
   height: ${rem(56)};
   margin: 0 ${rem(16)};
-  padding: ${rem(16)} 0 ${rem(20)};
+  padding: ${rem(16)} 0;
   font-size: ${rem(13)};
   border: none;
   background-color: transparent;

--- a/src/application/Layouts/Navigation.tsx
+++ b/src/application/Layouts/Navigation.tsx
@@ -7,32 +7,32 @@ import { colors } from "@apollo/space-kit/colors";
 import { ApolloLogo } from "@apollo/space-kit/icons/ApolloLogo";
 
 export enum Screens {
-  Cache = 'cache',
-  Queries = 'queries',
-  Mutations = 'mutations',
-  Explorer = 'explorer',
-};
+  Cache = "cache",
+  Queries = "queries",
+  Mutations = "mutations",
+  Explorer = "explorer",
+}
 
 type NavButtonProps = {
-  isSelected: boolean,
-  onClick: any,
+  isSelected: boolean;
+  onClick: any;
 };
 
 export type NavigationProps = {
-  queriesCount: number,
-  mutationsCount: number,
+  queriesCount: number;
+  mutationsCount: number;
 };
 
 const navigationStyles = css`
   display: flex;
   align-items: center;
-  box-shadow: 0 ${rem(-1)} 0 0 rgba(255, 255, 255, .3) inset;
+  box-shadow: 0 ${rem(-1)} 0 0 rgba(255, 255, 255, 0.3) inset;
   background-color: var(--primary);
 `;
 
 const selectedNavButtonStyles = css`
   color: ${colors.silver.lighter};
-  box-shadow: 0 ${rem(-1)} 0 0 ${colors.silver.lighter} inset;
+  box-shadow: 0 ${rem(-2)} 0 0 ${colors.silver.lighter} inset;
 `;
 
 const navButtonStyles = css`
@@ -50,21 +50,26 @@ const navButtonStyles = css`
   &:hover {
     color: ${colors.silver.lighter};
   }
+
+  &:focus {
+    outline: none;
+  }
 `;
 
-const NavButton: React.FC<NavButtonProps>  = ({ isSelected, onClick, children }) => (
+const NavButton: React.FC<NavButtonProps> = ({
+  isSelected,
+  onClick,
+  children,
+}) => (
   <button
-    css={[
-      navButtonStyles, 
-      isSelected && selectedNavButtonStyles,
-    ]}
+    css={[navButtonStyles, isSelected && selectedNavButtonStyles]}
     onClick={onClick}
   >
     {children}
   </button>
 );
 
-const listStyles = css` 
+const listStyles = css`
   display: flex;
   align-items: center;
   margin: 0 ${rem(16)};
@@ -85,20 +90,22 @@ const borderStyles = css`
 
 export const currentScreen = makeVar<Screens>(Screens.Queries);
 
-export const Navigation: React.FC<NavigationProps> = ({ queriesCount, mutationsCount }) => {
+export const Navigation: React.FC<NavigationProps> = ({
+  queriesCount,
+  mutationsCount,
+}) => {
   const selected = useReactiveVar<Screens>(currentScreen);
   const isSelected = (NavButton: Screens) => selected === NavButton;
   const onNavigate = (screen: Screens) => currentScreen(screen);
 
   return (
-    <nav 
-      css={navigationStyles}>
+    <nav css={navigationStyles}>
       <div css={borderStyles}>
         <ApolloLogo css={logoStyles} />
       </div>
       <ul css={listStyles}>
         <li>
-          <NavButton 
+          <NavButton
             isSelected={isSelected(Screens.Explorer)}
             onClick={() => onNavigate(Screens.Explorer)}
           >
@@ -106,7 +113,7 @@ export const Navigation: React.FC<NavigationProps> = ({ queriesCount, mutationsC
           </NavButton>
         </li>
         <li>
-          <NavButton 
+          <NavButton
             isSelected={isSelected(Screens.Queries)}
             onClick={() => onNavigate(Screens.Queries)}
           >
@@ -114,7 +121,7 @@ export const Navigation: React.FC<NavigationProps> = ({ queriesCount, mutationsC
           </NavButton>
         </li>
         <li>
-          <NavButton 
+          <NavButton
             isSelected={isSelected(Screens.Mutations)}
             onClick={() => onNavigate(Screens.Mutations)}
           >
@@ -122,7 +129,7 @@ export const Navigation: React.FC<NavigationProps> = ({ queriesCount, mutationsC
           </NavButton>
         </li>
         <li>
-          <NavButton 
+          <NavButton
             isSelected={isSelected(Screens.Cache)}
             onClick={() => onNavigate(Screens.Cache)}
           >

--- a/src/application/__tests__/App.test.tsx
+++ b/src/application/__tests__/App.test.tsx
@@ -1,53 +1,57 @@
-import React from 'react';
-import { waitFor } from '@testing-library/react';
-import { renderWithApolloClient } from '../utilities/testing/renderWithApolloClient';
-import { currentScreen, Screens } from '../Layouts/Navigation';
-import { App, reloadStatus } from '../App';
+import React from "react";
+import { waitFor } from "@testing-library/react";
+import { renderWithApolloClient } from "../utilities/testing/renderWithApolloClient";
+import { currentScreen, Screens } from "../Layouts/Navigation";
+import { App, reloadStatus } from "../App";
 
-jest.mock('../Queries/Queries', () => ({
-  Queries: ({ navigationProps }) => (<div>Queries ({navigationProps.queriesCount})</div>), 
+jest.mock("../Queries/Queries", () => ({
+  Queries: ({ navigationProps }) => (
+    <div>Queries ({navigationProps.queriesCount})</div>
+  ),
 }));
-jest.mock('../Mutations/Mutations', () => ({
-  Mutations: ({ navigationProps }) => (<div>Mutations ({navigationProps.mutationsCount})</div>), 
+jest.mock("../Mutations/Mutations", () => ({
+  Mutations: ({ navigationProps }) => (
+    <div>Mutations ({navigationProps.mutationsCount})</div>
+  ),
 }));
-jest.mock('../Explorer/Explorer', () => ({
-  Explorer: () => (<div>Explorer</div>), 
+jest.mock("../Explorer/Explorer", () => ({
+  Explorer: () => <div>Build</div>,
 }));
 
-describe('<App />', () => {
-  test('renders the selected screen', async () => {
+describe("<App />", () => {
+  test("renders the selected screen", async () => {
     const { getByText } = renderWithApolloClient(<App />);
-    expect(getByText('Queries (0)')).toBeInTheDocument();
+    expect(getByText("Queries (0)")).toBeInTheDocument();
     await waitFor(() => {
       currentScreen(Screens.Mutations);
       expect(currentScreen()).toEqual(Screens.Mutations);
     });
-    await waitFor(() => expect(getByText('Mutations (0)')).toBeInTheDocument());
+    await waitFor(() => expect(getByText("Mutations (0)")).toBeInTheDocument());
     await waitFor(() => {
       currentScreen(Screens.Explorer);
       expect(currentScreen()).toEqual(Screens.Explorer);
     });
-    await waitFor(() => expect(getByText('Explorer')).toBeInTheDocument());
+    await waitFor(() => expect(getByText("Build")).toBeInTheDocument());
   });
 
-  test('after reload, renders the Queries screen', async () => {
+  test("after reload, renders the Queries screen", async () => {
     currentScreen(Screens.Mutations);
     const { getByText, debug } = renderWithApolloClient(<App />);
-    const element = getByText('Mutations (0)');
+    const element = getByText("Mutations (0)");
     expect(element).toBeInTheDocument();
     await waitFor(() => {
       reloadStatus(true);
       expect(reloadStatus()).toBeTruthy();
     });
     await waitFor(() => {
-      expect(element).not.toBeInTheDocument()
+      expect(element).not.toBeInTheDocument();
     });
     await waitFor(() => {
       reloadStatus(false);
       expect(reloadStatus()).toBeFalsy();
     });
     await waitFor(() => {
-      expect(getByText('Queries (0)')).toBeInTheDocument()
+      expect(getByText("Queries (0)")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
A few quick graphiql-explorer integration improvements:

- Remove the "Explorer" name to reduce confusion with Apollo Studio Explorer
- Clean up graphiql-explorer styles
- Prevent empty graphiql-explorer started queries from being run by graphiql