### PR TITLE
Update the `@apollo/client` dep to pull in `ts-invariant` changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,27 @@
 {
   "name": "apollo-client-devtools",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.12.tgz",
-      "integrity": "sha512-1wLVqRpujzbLRWmFPnRCDK65xapOe2txY0sTI+BaqEbumMUVNS3vxojT6hRHf9ODFEK+F6MLrud2HGx0mB3eQw==",
+      "version": "3.4.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.0-beta.15.tgz",
+      "integrity": "sha512-xFi9q0PvC6lkQY/ympzQsj1BcptokVfd4MMfbd4XX1wbf1P1nztI8MpkIEiN5chIKtkO0NiS+bsW/DnRd+tQ1w==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
-        "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
         "@wry/equality": "^0.3.0",
+        "@wry/trie": "^0.2.1",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.12.0",
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.6.2",
+        "ts-invariant": "^0.7.0",
         "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
+        "zen-observable-ts": "^1.0.0"
       }
     },
     "@apollo/space-kit": {
@@ -12992,9 +12992,9 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.2.tgz",
-      "integrity": "sha512-hsVurayufl1gXg8CHtgZkB7X0KtA3TrI3xcJ9xkRr8FeJHnM/TIEQkgBq9XkpduyBWWUdlRIR9xWf4Lxq3LJTg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.0.tgz",
+      "integrity": "sha512-Ar5Y6ZSWZsN/e6A2WtbK8G0Z/+Qy6wsOOcucdoLQ2JZnbuorlEnXH003Ym6i4+X3C8rZNNmplYuingSQ8JSiWA==",
       "requires": {
         "@types/ungap__global-this": "^0.3.1",
         "@ungap/global-this": "^0.4.2",
@@ -14374,6 +14374,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.0.0.tgz",
+      "integrity": "sha512-KmWcbz+9kKUeAQ8btY8m1SsEFgBcp7h/Uf3V5quhan7ZWdjGsf0JcGLULQiwOZibbFWnHkYq8Nn2AZbJabovQg==",
+      "requires": {
+        "@types/zen-observable": "^0.8.2",
+        "zen-observable": "^0.8.15"
+      }
     },
     "zip-dir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "cd node_modules/graphiql-forked/packages/graphiql && npm install --production"
   },
   "dependencies": {
-    "@apollo/client": "latest",
+    "@apollo/client": "^3.4.0-beta.15",
     "@apollo/space-kit": "^9.0.1-canary.317.8374.0",
     "@emotion/cache": "^11.1.3",
     "@emotion/react": "^11.1.5",

--- a/src/application/components/Cache/__tests__/Cache.test.tsx
+++ b/src/application/components/Cache/__tests__/Cache.test.tsx
@@ -3,7 +3,7 @@ import { within, waitFor, fireEvent } from "@testing-library/react";
 
 import { Cache } from "../Cache";
 import { renderWithApolloClient } from "../../../utilities/testing/renderWithApolloClient";
-import { writeData } from "../../../index";
+import { client, writeData } from "../../../index";
 
 const CACHE_DATA = {
   "Result:1": {
@@ -57,6 +57,8 @@ describe("Cache component tests", () => {
 
   describe("With cache data", () => {
     beforeEach(() => {
+      client.resetStore();
+
       writeData({
         queries: [],
         mutations: [],


### PR DESCRIPTION
The issues fixed by #460 didn't quite go far enough. This commit updates to more recent versions of `@apollo/client`, and ultimately `ts-invariant`, to pull in the changes made in https://github.com/apollographql/invariant-packages/pull/94.

Fixes #457