### PR TITLE
Keep variables when using the "Run in GraphiQL" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Make sure null and boolean values are rendered properly in the Cache tree. <br/>
   [@alexTayanovsky](https://github.com/alexTayanovsky) in [#446](https://github.com/apollographql/apollo-client-devtools/pull/446)
 - Delay the loading / initialization of Apollo Client on each browser tab until it is really needed. <br/>
-  [@hwillson](https://github.com/apollographql/apollo-client-devtools) in [#479](https://github.com/apollographql/apollo-client-devtools/pull/479)
+  [@hwillson](https://github.com/hwillson) in [#479](https://github.com/apollographql/apollo-client-devtools/pull/479)
+- Make sure variables are copied to the GraphiQL panel when using the "Run in GraphiQL" button. <br/>
+  [@hwillson](https://github.com/hwillson) in [#491](https://github.com/apollographql/apollo-client-devtools/pull/491)
 
 ## 3.0.2 (2021-03-17)
 

--- a/src/application/components/Mutations/Mutations.tsx
+++ b/src/application/components/Mutations/Mutations.tsx
@@ -82,6 +82,7 @@ export const Mutations = ({ navigationProps }) => {
               <span css={operationNameStyles}>Mutation</span>
               <RunInGraphiQLButton
                 operation={selectedMutationData?.mutation?.mutationString}
+                variables={selectedMutationData?.mutation?.variables}
               />
             </Fragment>
           )}

--- a/src/application/components/Queries/Queries.tsx
+++ b/src/application/components/Queries/Queries.tsx
@@ -113,6 +113,7 @@ export const Queries = ({ navigationProps }) => {
               <span css={operationNameStyles}>Query</span>
               <RunInGraphiQLButton
                 operation={watchedQueryData?.watchedQuery?.queryString}
+                variables={watchedQueryData?.watchedQuery?.variables}
               />
             </Fragment>
           )}

--- a/src/application/components/Queries/RunInGraphiQLButton.tsx
+++ b/src/application/components/Queries/RunInGraphiQLButton.tsx
@@ -4,11 +4,12 @@ import { IconRun } from "@apollo/space-kit/icons/IconRun";
 import { jsx, css } from "@emotion/react";
 import { rem } from "polished";
 
-import { graphiQLQuery } from "../Explorer/Explorer";
+import { graphiQLOperation } from "../Explorer/Explorer";
 import { currentScreen, Screens } from "../Layouts/Navigation";
 
 interface RunInGraphiQLButtonProps {
   operation: string;
+  variables?: Record<string, any>;
 }
 
 export const buttonStyles = css`
@@ -31,11 +32,12 @@ export const buttonStyles = css`
 
 export const RunInGraphiQLButton = ({
   operation,
+  variables,
 }: RunInGraphiQLButtonProps) => (
   <button
     css={buttonStyles}
     onClick={() => {
-      graphiQLQuery(operation);
+      graphiQLOperation({ operation, variables });
       currentScreen(Screens.Explorer);
     }}
   >

--- a/src/application/components/Queries/__tests__/RunInGraphiQLButton.test.tsx
+++ b/src/application/components/Queries/__tests__/RunInGraphiQLButton.test.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { render } from "@testing-library/react";
 import user from "@testing-library/user-event";
 
-import { graphiQLQuery } from "../../Explorer/Explorer";
+import { graphiQLOperation } from "../../Explorer/Explorer";
 import { currentScreen } from "../../Layouts/Navigation";
 import { RunInGraphiQLButton } from "../RunInGraphiQLButton";
 
 jest.mock("../../Explorer/Explorer", () => ({
-  graphiQLQuery: jest.fn(),
+  graphiQLOperation: jest.fn(),
 }));
 
 jest.mock("../../Layouts/Navigation", () => ({
@@ -18,8 +18,8 @@ jest.mock("../../Layouts/Navigation", () => ({
 describe("<RunInGraphiQLButton />", () => {
   const props = {
     operation: `
-      query GetSavedColors {
-        favoritedColors {
+      query GetSavedColors($filter: String!) {
+        favoritedColors(filter: $filter) {
           ...colorFields
         }
       }
@@ -30,15 +30,20 @@ describe("<RunInGraphiQLButton />", () => {
         contrast
       }
     `,
+    variables: {
+      filter: "red",
+    },
   };
 
-  test("saves the operation and navigates to the Explorer panel", () => {
+  it("should save the operation + variables and navigate to the Explorer panel", () => {
     const { getByText } = render(<RunInGraphiQLButton {...props} />);
-
     const button = getByText("Run in GraphiQL");
     expect(button).toBeInTheDocument();
     user.click(button);
-    expect(graphiQLQuery).toHaveBeenCalledWith(props.operation);
+    expect(graphiQLOperation).toHaveBeenCalledWith({
+      operation: props.operation,
+      variables: props.variables,
+    });
     expect(currentScreen).toHaveBeenCalledWith("explorer");
   });
 });


### PR DESCRIPTION
These changes make sure variables are copied into the GraphiQL panel when using the "Run in GraphiQL" button on either the Queries or Mutations panel.

Fixes #458