### PR TITLE
Do not crash when the query.document is null #456

### DIFF
--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -121,7 +121,7 @@ export function getQueryData(query, key: number): WatchedQuery | undefined {
   // TODO: The current designs do not account for non-cached data.
   // We need a workaround to show that data + we should surface
   // the FetchPolicy.
-  const name = getOperationName(query?.document);
+  const name = query?.document && getOperationName(query?.document);
   if (name === "IntrospectionQuery") {
     return;
   }


### PR DESCRIPTION
fixes #456