### PR TITLE
Make sure parsing invalid queries is handled in graphiql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.4 (2021-04-04)
+
+- Fix an issue where removing a field in graphiql caused a panel crash. <br/>
+  [@hwillson](https://github.com/hwillson) in [#508](https://github.com/apollographql/apollo-client-devtools/pull/508)
+
 ## 3.0.3 (2021-04-03)
 
 - Make sure null and boolean values are rendered properly in the Cache tree. <br/>

--- a/src/application/components/Explorer/Explorer.tsx
+++ b/src/application/components/Explorer/Explorer.tsx
@@ -269,6 +269,20 @@ function executeOperation({
   });
 }
 
+function prettifyOperation(operation) {
+  let newOp;
+  if (operation) {
+    try {
+      newOp = print(parse(operation));
+    } catch (error) {
+      newOp = operation;
+    }
+  } else {
+    newOp = operation;
+  }
+  return newOp;
+}
+
 export const Explorer = ({ navigationProps }) => {
   const graphiQLRef = useRef<GraphiQL>(null);
   const schema = useReactiveVar(graphiQLSchema);
@@ -323,7 +337,7 @@ export const Explorer = ({ navigationProps }) => {
           })
         }
         schema={schema}
-        query={!!operation ? print(parse(operation)) : operation}
+        query={prettifyOperation(operation)}
         variables={JSON.stringify(variables)}
         editorTheme={color === ColorTheme.Dark ? "dracula" : "graphiql"}
         onEditQuery={(newQuery) =>


### PR DESCRIPTION
Adds an extra catch to make sure the parsing of invalid queries doesn't lead to the graphiql panel crashing.

Fixes #507