### PR TITLE
Add a "Who is Apollo" section to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ This project is governed by the [Apollo Code of Conduct](https://www.apollograph
 - [@jcreighton](https://github.com/jcreighton) (Apollo)
 - [@benjamn](https://github.com/benjamn) (Apollo)
 - [@hwillson](https://github.com/hwillson) (Apollo)
+
+## Who is Apollo?
+
+[Apollo Graph Inc.](https://apollographql.com/) is the company behind the industry's leading tools for building applications with GraphQL:
+
+- [Apollo Client](https://www.apollographql.com/apollo-client/) – most popular GraphQL client for the web. Apollo also builds and maintains [apollo-ios](https://github.com/apollographql/apollo-ios) and [apollo-android](https://github.com/apollographql/apollo-android).
+- [Apollo Server](https://www.apollographql.com/docs/apollo-server/) – build a production-ready JavaScript GraphQL server in a schema-first way.
+- [Apollo Studio](https://www.apollographql.com/studio/develop/) – a turnkey portal for your GraphQL developers with the most feature-rich GraphQL IDE available, the [Apollo Explorer](https://www.apollographql.com/docs/studio/explorer/), and intelligent schema search and documentation.
+- [Apollo Federation](https://www.apollographql.com/apollo-federation) – create and manage a single data graph comprised of subgraphs that can be controlled and managed with independent lifecycles.
+
+We are fully committed to pushing the frontier of graph development forward across our developer tools in open source frameworks, hosted software tooling, developer extensions, and more.


### PR DESCRIPTION
We're trying to add this section to the main READMEs of all our projects (e.g. https://github.com/apollographql/apollo-client#who-is-apollo).