### PR TITLE
Remove changes to auto-prettify graphiql operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.5 (TBD)
+
+- Fix issues caused by auto-prettying graphiql operations, which can lead to the cursor jumping around in the graphiql editor. <br/>
+  [@hwillson](https://github.com/hwillson) in [#541](https://github.com/apollographql/apollo-client-devtools/pull/541)
+
 ## 3.0.4 (2021-04-04)
 
 - Fix an issue where removing a field in graphiql caused a panel crash. <br/>

--- a/src/application/components/Explorer/Explorer.tsx
+++ b/src/application/components/Explorer/Explorer.tsx
@@ -269,20 +269,6 @@ function executeOperation({
   });
 }
 
-function prettifyOperation(operation) {
-  let newOp;
-  if (operation) {
-    try {
-      newOp = print(parse(operation));
-    } catch (error) {
-      newOp = operation;
-    }
-  } else {
-    newOp = operation;
-  }
-  return newOp;
-}
-
 export const Explorer = ({ navigationProps }) => {
   const graphiQLRef = useRef<GraphiQL>(null);
   const schema = useReactiveVar(graphiQLSchema);
@@ -337,7 +323,7 @@ export const Explorer = ({ navigationProps }) => {
           })
         }
         schema={schema}
-        query={prettifyOperation(operation)}
+        query={operation}
         variables={JSON.stringify(variables)}
         editorTheme={color === ColorTheme.Dark ? "dracula" : "graphiql"}
         onEditQuery={(newQuery) =>


### PR DESCRIPTION
We'll need to find a better way to do this. Using the `print(parse(...))` approach (that's still being used by the graphiql prettify button) isn't great, as it removes the type from the operation being edited in the graphiql panel. For now though, this will fix issues like #538.

Fixes #538