### PR TITLE
Make sure fragment imports are resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix issues caused by auto-prettying graphiql operations, which can lead to the cursor jumping around in the graphiql editor. <br/>
   [@hwillson](https://github.com/hwillson) in [#541](https://github.com/apollographql/apollo-client-devtools/pull/541)
+- Make sure fragment imports are properly resolved. <br/>
+  [@hwillson](https://github.com/hwillson) in [#542](https://github.com/apollographql/apollo-client-devtools/pull/542)
 
 ## 3.0.4 (2021-04-04)
 

--- a/src/application/__tests__/AppProvider.test.tsx
+++ b/src/application/__tests__/AppProvider.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
+import { gql } from "@apollo/client";
 
 import matchMediaMock from "../utilities/testing/matchMedia";
 import { Mode, colorTheme } from "../theme";
@@ -28,18 +29,16 @@ describe("<AppProvider />", () => {
 
     beforeEach(() => {
       queryData = {
-        document: {
-          definitions: [
-            {
-              kind: "OperationDefinition",
-              name: {
-                value: "GetColorByHex",
-              },
-            },
-          ],
-        },
+        document: gql`
+          query GetColorByHex {
+            someQuery {
+              id
+              __typename
+            }
+          }
+        `,
         source: {
-          body: "query-string",
+          body: "some source",
         },
         variables: {
           color: "#ee82ee",
@@ -56,7 +55,8 @@ describe("<AppProvider />", () => {
         id: 0,
         __typename: "WatchedQuery",
         name: "GetColorByHex",
-        queryString: "query-string",
+        queryString:
+          "query GetColorByHex {\n  someQuery {\n    id\n    __typename\n  }\n}\n",
         variables: {
           color: "#ee82ee",
         },
@@ -82,6 +82,7 @@ describe("<AppProvider />", () => {
       expect(data).toBeUndefined();
     });
   });
+
   describe("getMutationData", () => {
     let mutationData;
 

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -130,7 +130,7 @@ export function getQueryData(query, key: number): WatchedQuery | undefined {
     id: key,
     __typename: "WatchedQuery",
     name,
-    queryString: query?.source?.body || print(query.document),
+    queryString: print(query.document),
     variables: query.variables,
     cachedData: query.cachedData,
   };


### PR DESCRIPTION
This was a regression caused by trying to extract a string based representation of an operation from a document AST's `source` property, to avoid making an extra call to `print`. While this works in a lot of cases, it does not handle source imports properly as the `#import ...` statement is present in `source`. This commit avoids using `source`, making sure we convert the AST into a string using `print`, to handle imports properly.

Fixes #462