### PR TITLE
Pt2: Live Subscriptions in Studio Explorer in Dev Tools

### DIFF
--- a/src/application/components/Explorer/Explorer.tsx
+++ b/src/application/components/Explorer/Explorer.tsx
@@ -17,10 +17,11 @@ import {
   receiveExplorerResponses,
   sendExplorerRequest,
   listenForResponse,
+  sendSubscriptionTerminationRequest,
 } from "./explorerRelay";
 import { FullWidthLayout } from "../Layouts/FullWidthLayout";
-import { EMBEDDABLE_EXPLORER_URL } from "../../../extension/constants";
 import { QueryResult } from "../../../types";
+import { EMBEDDABLE_EXPLORER_URL, SUBSCRIPTION_TERMINATION } from "../../../extension/constants";
 
 enum FetchPolicy {
   NoCache = "no-cache",
@@ -69,6 +70,13 @@ function executeOperation({
   operationName,
   variables,
   fetchPolicy,
+  isSubscription,
+}: {
+  operation: string,
+  operationName: string,
+  variables: string | null,
+  fetchPolicy: FetchPolicy,
+  isSubscription: boolean,
 }) {
   return new Observable<FetchResult>((observer) => {
     const payload = JSON.stringify({
@@ -80,9 +88,22 @@ function executeOperation({
 
     sendExplorerRequest(payload);
 
-    listenForResponse(operationName, (response) => {
+    listenForResponse(operationName, isSubscription, (response) => {
       observer.next(response);
-      observer.complete();
+      if(isSubscription) {
+        const checkForSubscriptionTermination = (event: MessageEvent) => {
+          if(event.data.name.startsWith(SUBSCRIPTION_TERMINATION)) {
+            sendSubscriptionTerminationRequest();
+            observer.complete();
+            window.removeEventListener('message', checkForSubscriptionTermination);
+          }
+        }
+
+        window.addEventListener('message', checkForSubscriptionTermination);
+      }
+      else {
+        observer.complete();
+      }
     });
   });
 }
@@ -132,6 +153,7 @@ export const Explorer = ({ navigationProps, embeddedExplorerProps }: {
         operation: getIntrospectionQuery(),
         operationName: "IntrospectionQuery",
         variables: null,
+        isSubscription: false,
         fetchPolicy: FetchPolicy.NoCache,
       });
 
@@ -164,21 +186,21 @@ export const Explorer = ({ navigationProps, embeddedExplorerProps }: {
         variables: string,
         headers:string
       }>) => {
-        // Network request communications will come from the explorer
-        // in the form ExplorerRequest:id for queries and mutations
-        // and in the form ExplorerSubscriptionRequest:id for subscriptions
-        if(event.data.name.startsWith('ExplorerRequest:') || event.data.name.startsWith('ExplorerSubscriptionRequest:')) {
-          const currentOperationId = event.data.name.split(':')[1]
-          const observer = executeOperation({
+        const isQueryOrMutation = event.data.name.startsWith('ExplorerRequest:');
+        const isSubscription = event.data.name.startsWith('ExplorerSubscriptionRequest:');
+        const currentOperationId = event.data.name.split(':')[1]
+        if(isQueryOrMutation || isSubscription) {
+          const observer =  executeOperation({
             operation: event.data.operation,
             operationName: event.data.operationName,
             variables: event.data.variables,
-            fetchPolicy: FetchPolicy.NoCache,
+            fetchPolicy: queryCache,
+            isSubscription,
           });
 
           observer.subscribe((response) => {
             embeddedExplorerIFrame.contentWindow?.postMessage({
-              name: event.data.name.startsWith('ExplorerRequest:') ?
+              name: isQueryOrMutation ?
                 `ExplorerResponse:${currentOperationId}` :
                 `ExplorerSubscriptionResponse:${currentOperationId}`,
               response: response

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -15,3 +15,4 @@ export const RELOADING_TAB = "reloading-tab";
 export const RELOAD_TAB_COMPLETE = "reload-tab-complete";
 export const EMBEDDABLE_EXPLORER_URL =
   "https://explorer.embed.apollographql.com";
+export const SUBSCRIPTION_TERMINATION = "ExplorerSubscriptionTermination";

--- a/src/extension/devtools/panel.ts
+++ b/src/extension/devtools/panel.ts
@@ -6,6 +6,7 @@ import {
 } from "../../application";
 import {
   receiveExplorerRequests,
+  receiveSubscriptionTerminationRequest,
   sendResponseToExplorer,
 } from "../../application/components/Explorer/explorerRelay";
 
@@ -13,6 +14,7 @@ import {
   initialize: initDevTools,
   writeData,
   receiveExplorerRequests,
+  receiveSubscriptionTerminationRequest,
   sendResponseToExplorer,
   handleReload,
   handleReloadComplete,

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -27,6 +27,7 @@ import {
   UPDATE,
   RELOADING_TAB,
   RELOAD_TAB_COMPLETE,
+  SUBSCRIPTION_TERMINATION,
 } from "../constants";
 
 declare global {
@@ -177,7 +178,7 @@ function initializeHook() {
       }
     })();
 
-    operation?.subscribe(
+    const operationObservable = operation?.subscribe(
       (response: QueryResult) => {
         handleExplorerResponse({
           operationName,
@@ -201,6 +202,15 @@ function initializeHook() {
         });
       }
     );
+
+    if (
+      definition.kind === "OperationDefinition" &&
+      definition.operation === "subscription"
+    ) {
+      clientRelay.listen(SUBSCRIPTION_TERMINATION, () => {
+        operationObservable?.unsubscribe();
+      });
+    }
   });
 
   function findClient() {


### PR DESCRIPTION
Previously in dev tools, subscription data was only reported when the button was pressed, even though we kept the socket open indefinitely. This PR shows data in realtime as we receive it, and closes the connection from the client when we receive a Subscription Termination Request from the embedded explorer.

Before:
https://user-images.githubusercontent.com/14367451/129082611-39a81f60-e756-478e-80d5-3c95effe5d25.mov

After:

https://user-images.githubusercontent.com/14367451/129082870-d5ee308a-ba3f-43a3-9bc1-65adbe8ddad0.mov


