### PR TITLE
Some small fixes I made as I was iterating on Embeddable Explorer

### DIFF
--- a/src/application/components/Explorer/explorerRelay.ts
+++ b/src/application/components/Explorer/explorerRelay.ts
@@ -3,7 +3,7 @@ import { ExplorerResponse, QueryResult, MessageObj } from "../../../types";
 import {
   EXPLORER_RESPONSE,
   EXPLORER_REQUEST,
-  SUBSCRIPTION_TERMINATION,
+  EXPLORER_SUBSCRIPTION_TERMINATION,
 } from "../../../extension/constants";
 
 const explorer = new Relay();
@@ -18,9 +18,9 @@ explorer.listen<ExplorerResponse>(EXPLORER_RESPONSE, ({ payload }) => {
 });
 
 export const listenForResponse = (
-  operationName: string,
-  isSubscription: boolean,
-  cb: (p) => void
+  cb: (p) => void,
+  operationName?: string,
+  isSubscription?: boolean
 ): void => {
   const removeListener = explorer.listen<QueryResult>(
     `explorer:response:${operationName}`,
@@ -31,7 +31,7 @@ export const listenForResponse = (
       if (!isSubscription) {
         removeListener();
       } else {
-        explorer.listen(SUBSCRIPTION_TERMINATION, () => {
+        explorer.listen(EXPLORER_SUBSCRIPTION_TERMINATION, () => {
           removeListener();
         });
       }
@@ -41,9 +41,9 @@ export const listenForResponse = (
 
 export const sendSubscriptionTerminationRequest = (): void => {
   window.dispatchEvent(
-    new CustomEvent(SUBSCRIPTION_TERMINATION, {
+    new CustomEvent(EXPLORER_SUBSCRIPTION_TERMINATION, {
       detail: {
-        message: SUBSCRIPTION_TERMINATION,
+        message: EXPLORER_SUBSCRIPTION_TERMINATION,
         payload: undefined,
       },
     })
@@ -71,9 +71,9 @@ export const receiveExplorerRequests = (callback: () => void): (() => void) => {
 export const receiveSubscriptionTerminationRequest = (
   callback: () => void
 ): (() => void) => {
-  window.addEventListener(SUBSCRIPTION_TERMINATION, callback);
+  window.addEventListener(EXPLORER_SUBSCRIPTION_TERMINATION, callback);
   return () => {
-    window.removeEventListener(SUBSCRIPTION_TERMINATION, callback);
+    window.removeEventListener(EXPLORER_SUBSCRIPTION_TERMINATION, callback);
   };
 };
 

--- a/src/extension/constants.ts
+++ b/src/extension/constants.ts
@@ -15,4 +15,5 @@ export const RELOADING_TAB = "reloading-tab";
 export const RELOAD_TAB_COMPLETE = "reload-tab-complete";
 export const EMBEDDABLE_EXPLORER_URL =
   "https://explorer.embed.apollographql.com";
-export const SUBSCRIPTION_TERMINATION = "ExplorerSubscriptionTermination";
+export const EXPLORER_SUBSCRIPTION_TERMINATION =
+  "ExplorerSubscriptionTermination";

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -9,7 +9,7 @@ import {
   EXPLORER_REQUEST,
   RELOADING_TAB,
   RELOAD_TAB_COMPLETE,
-  SUBSCRIPTION_TERMINATION,
+  EXPLORER_SUBSCRIPTION_TERMINATION,
 } from "../constants";
 
 const inspectedTabId = chrome.devtools.inspectedWindow.tabId;
@@ -46,8 +46,8 @@ sendMessageToClient(DEVTOOLS_INITIALIZED);
 let isPanelCreated = false;
 let isAppInitialized = false;
 
-devtools.addConnection(SUBSCRIPTION_TERMINATION, () => {
-  sendMessageToClient(SUBSCRIPTION_TERMINATION);
+devtools.addConnection(EXPLORER_SUBSCRIPTION_TERMINATION, () => {
+  sendMessageToClient(EXPLORER_SUBSCRIPTION_TERMINATION);
 });
 
 devtools.listen(CREATE_DEVTOOLS_PANEL, ({ payload }) => {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -27,7 +27,7 @@ import {
   UPDATE,
   RELOADING_TAB,
   RELOAD_TAB_COMPLETE,
-  SUBSCRIPTION_TERMINATION,
+  EXPLORER_SUBSCRIPTION_TERMINATION,
 } from "../constants";
 
 declare global {
@@ -207,7 +207,7 @@ function initializeHook() {
       definition.kind === "OperationDefinition" &&
       definition.operation === "subscription"
     ) {
-      clientRelay.listen(SUBSCRIPTION_TERMINATION, () => {
+      clientRelay.listen(EXPLORER_SUBSCRIPTION_TERMINATION, () => {
         operationObservable?.unsubscribe();
       });
     }


### PR DESCRIPTION
renamed SUBCRIPTION_TERMINATION to EXPLORER_SUBSCRIPTION_TERMINATION to match the other constants & make some props optional, since they are optional when we send them from the embeddable explorer. Also updated the type of `variables` to match the embeddable explorer.