### PR TITLE
Query param renames

### DIFF
--- a/src/application/components/Explorer/Explorer.tsx
+++ b/src/application/components/Explorer/Explorer.tsx
@@ -255,7 +255,7 @@ export const Explorer = ({ navigationProps, embeddedExplorerProps }: {
           </label>
         </FullWidthLayout.Header>
         <FullWidthLayout.Main css={mainStyles}>
-          <iframe id="embedded-explorer" css={iFrameStyles} src={`${EMBEDDABLE_EXPLORER_URL}?postMessageOperations=true&showHeadersAndEnvVars=false&theme=${color}`}/>
+          <iframe id="embedded-explorer" css={iFrameStyles} src={`${EMBEDDABLE_EXPLORER_URL}?sendRequestsFrom=parent&shouldPersistState=true&showHeadersAndEnvVars=false&theme=${color}`}/>
         </FullWidthLayout.Main>
     </FullWidthLayout>
   );

--- a/src/application/components/Explorer/Explorer.tsx
+++ b/src/application/components/Explorer/Explorer.tsx
@@ -255,7 +255,7 @@ export const Explorer = ({ navigationProps, embeddedExplorerProps }: {
           </label>
         </FullWidthLayout.Header>
         <FullWidthLayout.Main css={mainStyles}>
-          <iframe id="embedded-explorer" css={iFrameStyles} src={`${EMBEDDABLE_EXPLORER_URL}?sendRequestsFrom=parent&shouldPersistState=true&showHeadersAndEnvVars=false&theme=${color}`}/>
+          <iframe id="embedded-explorer" css={iFrameStyles} src={`${EMBEDDABLE_EXPLORER_URL}?sendRequestsFrom=parent&shouldPersistState=false&showHeadersAndEnvVars=false&theme=${color}`}/>
         </FullWidthLayout.Main>
     </FullWidthLayout>
   );


### PR DESCRIPTION
We just changed the names of these this week :). `shouldPersistState` is whether or not to keep state in local storage. Do we want this to be true or false for dev tools? Do folks expect a clean explorer when they come to dev tools?