### PR TITLE
fix content background color

### DIFF
--- a/src/application/components/Layouts/SidebarLayout.tsx
+++ b/src/application/components/Layouts/SidebarLayout.tsx
@@ -53,6 +53,7 @@ const contentStyles = css`
     "main";
   height: 100vh;
   overflow: auto;
+  background-color: var(--main);
 `;
 
 const headerStyles = css`


### PR DESCRIPTION
Establish a background color for the `content` section to avoid a white background when using the dark mode and its content does not fit the whole height. This is unnoticed with the light mode as the default background matches with the `--main` color.

### Before:

![Query panel of the Apollo Chrome extension showing an un-painted white section](https://user-images.githubusercontent.com/829269/148423431-918ef593-ddac-4cfc-aff5-c9acb191f5d8.png)

### After:

![The same query panel as before, but without the white section](https://user-images.githubusercontent.com/829269/148423558-e1886bbf-780d-447e-86d7-196713beceb6.png)
