### PR TITLE
use "pagehide" instead of "beforeunload"

### DIFF
--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -81,9 +81,9 @@ function initializeHook() {
   }
 
   // Listen for tab refreshes
-  window.onbeforeunload = () => {
+  window.addEventListener("pagehide", () => {
     sendMessageToTab(RELOADING_TAB);
-  };
+  });
 
   window.addEventListener("load", () => {
     sendMessageToTab(RELOAD_TAB_COMPLETE, {


### PR DESCRIPTION
Changes the way the "leaving page" listener is added:

* Uses `pagehide` instead of `beforeunload` which can unreliably fire, so it is not guaranteed that the leaving listener will be called.
 
* `beforeunload` also breaks the browsers' bfcache / page cache and because the hook is injected on every website visited, all sites are becoming slower to load when navigating back / forward if the extension is loaded. [More information about the page lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api).

* Uses `addEventListener` instead of `on` + listener: when the page monitored also defines an `onbeforeunload` state the original hook listener is lost.