### PR TITLE
fix(ui): fixes height of query, mutation, and cache content

### DIFF
--- a/src/application/components/Layouts/SidebarLayout.tsx
+++ b/src/application/components/Layouts/SidebarLayout.tsx
@@ -72,6 +72,7 @@ const mainStyles = css`
   padding: 0 1rem 2rem;
   background-color: var(--main);
   color: var(--textPrimary);
+  height: calc(100vh - 2.5rem);
 `;
 
 const SidebarLayout: React.FC<SidebarLayoutProps> &


### PR DESCRIPTION
## Fix

This fixes the height of the query content not taking the full height of the window.

### Before
![image](https://user-images.githubusercontent.com/66273043/157572550-a4e84127-1e3e-4f5b-a17c-f00e4ba775ce.png)


### After
![image](https://user-images.githubusercontent.com/66273043/157572642-b9a6e412-9c21-4aec-b942-407a15364100.png)


I believe this is because we forgot to set the height like we did in the here:
https://github.com/apollographql/apollo-client-devtools/blob/dc36a50dfdb82000401bfa6a0f6589069600c2d2/src/application/components/Layouts/FullWidthLayout.tsx#L27-L30

## Steps to reproduce bug
1. go to https://codesandbox.io/s/apollo-client-devtool-variables-forked-fuoro5
2. open apollo devtools and view one of the queries
3. notice it doesn't take the full height