### PR TITLE
feat: find apollo client instance on embedded iframes

### DIFF
--- a/development/client/public/iframe.html
+++ b/development/client/public/iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Color App in an IFrame</title>
+</head>
+
+<body>
+  <iframe src="../index.html" style="width: 100%; height: 600px;">
+</body>
+
+</html>

--- a/src/extension/tab/__tests__/hook.test.ts
+++ b/src/extension/tab/__tests__/hook.test.ts
@@ -1,0 +1,57 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { findClient } from '../hook';
+
+const cache = new InMemoryCache();
+
+describe('findClient', () => {
+  beforeEach(() => {
+    window.__APOLLO_CLIENT__ = undefined;
+    window.document.body.innerHTML = ``;
+  });
+
+  it('should find the client on the provided window object', () => {
+    const expectedClient = new ApolloClient({ cache });
+
+    const client = findClient();
+    expect(client).toEqual(expectedClient);
+  });
+
+  it('should find the client on an embedded iframe', () => {
+    const expectedClient = new ApolloClient({ cache, connectToDevTools: false });
+
+    const iframe = document.createElement('iframe');
+
+    window.document.body.appendChild(iframe);
+
+    iframe.contentWindow!.__APOLLO_CLIENT__ = expectedClient;
+
+    const client = findClient();
+    expect(client).toEqual(expectedClient);
+  });
+
+  it('should find the client in a nested iframe', () => {
+    const expectedClient = new ApolloClient({ cache, connectToDevTools: false });
+
+    const iframe = document.createElement('iframe');
+    const nestedIframe = document.createElement('iframe');
+
+    window.document.body.appendChild(iframe);
+
+    iframe.contentDocument!.body.appendChild(nestedIframe);
+    nestedIframe.contentWindow!.__APOLLO_CLIENT__ = expectedClient;
+
+    const client = findClient();
+    expect(client).toEqual(expectedClient);
+  });
+
+  it('should return undefined if no client instance is found', () => {
+    const iframe = document.createElement('iframe');
+    const nestedIframe = document.createElement('iframe');
+
+    window.document.body.appendChild(iframe);
+    iframe.contentDocument!.body.appendChild(nestedIframe);
+
+    const client = findClient();
+    expect(client).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Per https://github.com/apollographql/apollo-client-devtools/discussions/380.

This PR adds discovery support for apollo client instances in same-origin iframes. It does so by looking through any embedded iframes and looking for window.__APOLLO_CLIENT__ instances therein.

I also added an iframe.html file to the client repo to test and validate the behavior; committing it may be overkill since it's not core functionality but willing to get feedback on that. Can verify by starting the local app with `npm run start:dev` and navigating to localhost:3000/iframe.html, which will load the demo app in an iframe.