### PR TITLE
🐛 Improve reliability of devtools initializing 

### DIFF
--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -41,8 +41,6 @@ function startRequestInterval(ms = 500) {
   return () => clearInterval(id);
 }
 
-sendMessageToClient(DEVTOOLS_INITIALIZED);
-
 let isPanelCreated = false;
 let isAppInitialized = false;
 
@@ -139,3 +137,5 @@ devtools.listen(CREATE_DEVTOOLS_PANEL, ({ payload }) => {
     );
   }
 });
+
+sendMessageToClient(DEVTOOLS_INITIALIZED);

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -235,6 +235,9 @@ function initializeHook() {
 
         clearInterval(interval);
         sendMessageToTab(CLIENT_FOUND);
+        // incase initial update was missed because the client wasn't ready, send the create devtools event.
+        // devtools checks to see if it's already created, so this won't create duplicate tabs
+        sendHookDataToDevTools(CREATE_DEVTOOLS_PANEL);
       }
     }
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -99,31 +99,25 @@ function initializeHook() {
     sendMessageToTab(EXPLORER_RESPONSE, payload);
   }
 
-  clientRelay.listen(DEVTOOLS_INITIALIZED, () => {
-    if (hook.ApolloClient) {
-      // Tab Relay forwards this the devtools
-      sendMessageToTab(
-        CREATE_DEVTOOLS_PANEL,
-        JSON.stringify({
-          queries: hook.getQueries(),
-          mutations: hook.getMutations(),
-          cache: hook.getCache(),
-        })
-      );
-    }
-  });
-
-  clientRelay.listen(REQUEST_DATA, () => {
+  function sendHookDataToDevTools(eventName: typeof CREATE_DEVTOOLS_PANEL | typeof UPDATE) {
     // Tab Relay forwards this the devtools
     sendMessageToTab(
-      UPDATE,
+      eventName,
       JSON.stringify({
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
         cache: hook.getCache(),
       })
     );
+  }
+
+  clientRelay.listen(DEVTOOLS_INITIALIZED, () => {
+    if (hook.ApolloClient) {
+      sendHookDataToDevTools(CREATE_DEVTOOLS_PANEL);
+    }
   });
+
+  clientRelay.listen(REQUEST_DATA, () => sendHookDataToDevTools(UPDATE));
 
   clientRelay.listen(EXPLORER_REQUEST, ({ payload }) => {
     const {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -213,6 +213,9 @@ function initializeHook() {
     }
   });
 
+  /**
+   * Attempt to find the client on a 1-second interval for 10 seconds max
+   */
   function findClient() {
     let interval;
     let count = 0;
@@ -245,7 +248,6 @@ function initializeHook() {
     initializeDevtoolsHook() // call immediately to reduce lag if devtools are already available
   }
 
-  // Attempt to find the client on a 1-second interval for 10 seconds max
   findClient();
 }
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -114,6 +114,9 @@ function initializeHook() {
   clientRelay.listen(DEVTOOLS_INITIALIZED, () => {
     if (hook.ApolloClient) {
       sendHookDataToDevTools(CREATE_DEVTOOLS_PANEL);
+    } else {
+      // try finding client again, if it's found findClient will send the CREATE_DEVTOOLS_PANEL event
+      findClient()
     }
   });
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -242,6 +242,7 @@ function initializeHook() {
     }
 
     interval = setInterval(initializeDevtoolsHook, 1000);
+    initializeDevtoolsHook() // call immediately to reduce lag if devtools are already available
   }
 
   // Attempt to find the client on a 1-second interval for 10 seconds max


### PR DESCRIPTION
The Apollo client devtools tab is inconsistently showing up, after investigating it seems there are a few race conditions between initializing the devtools and finding the Apollo client. This PR fixes a few of those race conditions to hopefully fix or at least improve the reliability of the devtools showing up.
