### PR TITLE
fix: cache data empty in queries tab

### DIFF
--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -22,12 +22,14 @@ export function getQueries(observableQueries: ObservableQuery[]): QueryInfo[] {
   const queries: QueryInfo[] = [];
   if (observableQueries) {
     observableQueries.forEach((observableQuery)=>{
-      const {document, variables, diff, lastDiff} = observableQuery.queryInfo;
+      const {document, variables} = observableQuery.queryInfo;
+      const diff = (observableQuery.queryInfo as any).getDiff();
+
       queries.push({ 
         document, 
         source: document?.loc?.source,
         variables,
-        cachedData: diff?.result || lastDiff?.diff?.result,
+        cachedData: diff?.result,
       });
     })
   }

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -19,12 +19,12 @@ export function getQueries(queryMap): QueryInfo[] {
     queries = [...queryMap.values()].map(({
       document,
       variables,
-      diff,
+      lastDiff,
     }) => ({
         document,
         source: document?.loc?.source,
         variables,
-        cachedData: diff?.result,
+        cachedData: lastDiff?.diff?.result,
       })
     )
   }


### PR DESCRIPTION
This PR fixes the cache data empty issue in the `Queries` tab, fixes #816 

**Screenshots**

| BEFORE   | AFTER  |   
|---|---|
| <img width="1218" alt="image" src="https://user-images.githubusercontent.com/36567063/191275957-d92d0f56-0c48-4c4e-8eb8-67e359bb055e.png"> | <img width="1175" alt="image" src="https://user-images.githubusercontent.com/36567063/191275843-a6c4cd33-d991-4d1b-8141-2caef4ddda3f.png"> |  