### PR TITLE
Mitigate duplicate active queries appearing in the Queries sidebar

### DIFF
--- a/src/extension/tab/broadcastQueries.js
+++ b/src/extension/tab/broadcastQueries.js
@@ -2,12 +2,9 @@
 // a Map. Devtools are expecting to work with an object, so this function
 // will convert an AC3 query info Map to an object, while also filtering out
 // the query details we don't need.
-function filterQueryInfo(queryInfoMap, useObservableQueries) {
+function filterQueryInfo(queryInfoMap) {
   const filteredQueryInfo = {};
   queryInfoMap.forEach((value, key) => {
-    if (useObservableQueries){
-      value = value.queryInfo;
-    }
     filteredQueryInfo[key] = {
       document: value.document,
       graphQLErrors: value.graphQLErrors,
@@ -29,14 +26,9 @@ function getQueries(client) {
     if (client.queryManager.queryStore.getStore) {
       return () => client.queryManager.queryStore.getStore();
     }
-  } 
-  // Apollo Client < 3.4.0
-  else if (client.queryManager.queries) {
-    return () => filterQueryInfo(client.queryManager.queries, false);
-  }
-  // Apollo Client >= 3.4.0
-  else if (client.queryManager.getObservableQueries) {
-    return () => filterQueryInfo(client.queryManager.getObservableQueries("active"), true);
+  // Apollo Client 3
+  } else if (client.queryManager.queries) {
+    return () => filterQueryInfo(client.queryManager.queries);
   }
 }
 

--- a/src/extension/tab/broadcastQueries.js
+++ b/src/extension/tab/broadcastQueries.js
@@ -2,9 +2,12 @@
 // a Map. Devtools are expecting to work with an object, so this function
 // will convert an AC3 query info Map to an object, while also filtering out
 // the query details we don't need.
-function filterQueryInfo(queryInfoMap) {
+function filterQueryInfo(queryInfoMap, useObservableQueries) {
   const filteredQueryInfo = {};
   queryInfoMap.forEach((value, key) => {
+    if (useObservableQueries){
+      value = value.queryInfo;
+    }
     filteredQueryInfo[key] = {
       document: value.document,
       graphQLErrors: value.graphQLErrors,
@@ -26,9 +29,14 @@ function getQueries(client) {
     if (client.queryManager.queryStore.getStore) {
       return () => client.queryManager.queryStore.getStore();
     }
-  // Apollo Client 3
-  } else if (client.queryManager.queries) {
-    return () => filterQueryInfo(client.queryManager.queries);
+  } 
+  // Apollo Client < 3.4.0
+  else if (client.queryManager.queries) {
+    return () => filterQueryInfo(client.queryManager.queries, false);
+  }
+  // Apollo Client >= 3.4.0
+  else if (client.queryManager.getObservableQueries) {
+    return () => filterQueryInfo(client.queryManager.getObservableQueries("active"), true);
   }
 }
 

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -10,25 +10,26 @@ export type QueryInfo = {
   source?: Source,
   variables?: Record<string, any>;
   diff?: Record<string, any>;
+  cachedData?: any; // Not a member of the actual Apollo Client QueryInfo type
 }
 
-export function getQueries(queryMap): QueryInfo[] {
-  let queries: QueryInfo[] = [];
+type ObservableQuery = {
+  queryInfo: QueryInfo
+}
 
-  if (queryMap) {
-    queries = [...queryMap.values()].map(({
-      document,
-      variables,
-      diff,
-    }) => ({
-        document,
+export function getQueries(observableQueries: ObservableQuery[]): QueryInfo[] {
+  const queries: QueryInfo[] = [];
+  if (observableQueries) {
+    observableQueries.forEach((observableQuery)=>{
+      const {document, variables, diff} = observableQuery.queryInfo;
+      queries.push({ 
+        document, 
         source: document?.loc?.source,
         variables,
         cachedData: diff?.result,
-      })
-    )
+      });
+    })
   }
-
   return queries;
 }
 

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -17,6 +17,7 @@ type ObservableQuery = {
   queryInfo: QueryInfo
 }
 
+// Transform the map of observable queries into a list of QueryInfo objects usable by DevTools
 export function getQueries(observableQueries: ObservableQuery[]): QueryInfo[] {
   const queries: QueryInfo[] = [];
   if (observableQueries) {
@@ -32,6 +33,25 @@ export function getQueries(observableQueries: ObservableQuery[]): QueryInfo[] {
   }
   return queries;
 }
+
+// Version of getQueries compatible with Apollo Client versions < 3.4.0
+export function getQueriesLegacy(queryMap: any): QueryInfo[] {
+    let queries: QueryInfo[] = [];
+    if (queryMap) {
+      queries = [...queryMap.values()].map(({
+        document,
+        variables,
+        diff,
+      }) => ({
+          document,
+          source: document?.loc?.source,
+          variables,
+          cachedData: diff?.result,
+        })
+      )
+    }
+    return queries;
+  }
 
 export function getMutations(mutationsObj): QueryInfo[] {
   const keys = Object.keys(mutationsObj);

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -12,6 +12,7 @@ import Relay from "../../Relay";
 import {
   QueryInfo,
   getQueries,
+  getQueriesLegacy,
   getMutations,
   getMainDefinition,
 } from "./helpers";
@@ -222,8 +223,13 @@ function initializeHook() {
       if (window.__APOLLO_CLIENT__) {
         hook.ApolloClient = window.__APOLLO_CLIENT__;
         hook.ApolloClient.__actionHookForDevTools(handleActionHookForDevtools);
-        hook.getQueries = () =>
-          getQueries((hook.ApolloClient as any).queryManager.getObservableQueries("active"))
+        hook.getQueries = () =>{
+          if((hook.ApolloClient as any).queryManager.getObservableQueries){
+            return getQueries((hook.ApolloClient as any).queryManager.getObservableQueries("active"));
+          } else {
+            return getQueriesLegacy((hook.ApolloClient as any).queryManager.queries);
+          }
+        }
         hook.getMutations = () =>
           getMutations(
             (hook.ApolloClient as any).queryManager.mutationStore?.getStore

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -223,7 +223,7 @@ function initializeHook() {
         hook.ApolloClient = window.__APOLLO_CLIENT__;
         hook.ApolloClient.__actionHookForDevTools(handleActionHookForDevtools);
         hook.getQueries = () =>
-          getQueries((hook.ApolloClient as any).queryManager.queries);
+          getQueries((hook.ApolloClient as any).queryManager.getObservableQueries("active"))
         hook.getMutations = () =>
           getMutations(
             (hook.ApolloClient as any).queryManager.mutationStore?.getStore


### PR DESCRIPTION
This issue resolves `JIRA-NEBULA-743`

The Client Dev Tools would ometimes show duplicate active queries in the left side-panel. I believe this is because when getting queries it would manually read from the private `queryManager.queries` field, which explains the unexpected behavior we've been getting.

I've changed the logic to instead use the `queryManager.getObservableQueries()` function, which is supported and does exactly what we're trying to do here (i.e., get a list of active queries)
Before:
![image](https://user-images.githubusercontent.com/29008542/193101840-ff167d05-1ec7-4fa1-b5b5-60e9faae37cf.png)

After:
![image](https://user-images.githubusercontent.com/29008542/193101707-cc5a88a1-ebbd-4e33-bbe5-c9edd6d3bb2f.png)
