### PR TITLE
Fix CI tests failing

### DIFF
--- a/src/application/components/Mutations/MutationViewer.tsx
+++ b/src/application/components/Mutations/MutationViewer.tsx
@@ -2,7 +2,7 @@
 
 import { jsx, css } from "@emotion/react";
 import { GraphQLCodeBlock } from "react-graphql-syntax-highlighter";
-import 'react-graphql-syntax-highlighter/dist/style';
+import 'react-graphql-syntax-highlighter/dist/style.css';
 
 import JSONTree from "react-json-tree";
 import { IconCopy } from "@apollo/space-kit/icons/IconCopy";

--- a/src/application/components/Queries/QueryViewer.tsx
+++ b/src/application/components/Queries/QueryViewer.tsx
@@ -6,7 +6,7 @@ import { rem } from "polished";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 import { colors } from "@apollo/space-kit/colors";
 import { GraphQLCodeBlock } from "react-graphql-syntax-highlighter";
-import 'react-graphql-syntax-highlighter/dist/style';
+import 'react-graphql-syntax-highlighter/dist/style.css';
 
 import JSONTree from "react-json-tree";
 import { IconCopy } from "@apollo/space-kit/icons/IconCopy";


### PR DESCRIPTION
https://github.com/apollographql/apollo-client-devtools/pull/930 was causing some tests to fail because of a stylesheet import that wasn't completely explicit. This PR fixes that by specifying `/dist/style.css` rather than `/dist/style` in the import statements.