### PR TITLE
Draft: Add support for iframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/cache": "^11.1.3",
         "@emotion/react": "^11.1.5",
         "@reach/tabs": "^0.18.0",
+        "cuid": "^2.1.8",
         "framer-motion": "^3.6.2",
         "graphql": "^15.5.0",
         "graphql-tag": "^2.11.0",
@@ -7116,6 +7117,11 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
       "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+    },
+    "node_modules/cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -24426,6 +24432,11 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
       "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+    },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg=="
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@emotion/cache": "^11.1.3",
     "@emotion/react": "^11.1.5",
     "@reach/tabs": "^0.18.0",
+    "cuid": "^2.1.8",
     "framer-motion": "^3.6.2",
     "graphql": "^15.5.0",
     "graphql-tag": "^2.11.0",

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { useReactiveVar, gql, useQuery, makeVar } from "@apollo/client";
 
-import { currentScreen, Screens } from "./components/Layouts/Navigation";
+import { currentScreen } from "./components/Layouts/Navigation";
+import { Screens } from "./components/Layouts/screens";
 import { Queries } from "./components/Queries/Queries";
 import { Mutations } from "./components/Mutations/Mutations";
 import { Explorer } from "./components/Explorer/Explorer";
@@ -69,8 +70,8 @@ export const App = (): JSX.Element => {
         <Screen
           isVisible={undefined}
           navigationProps={{
-            queriesCount: data?.client?.watchedQueries?.count,
-            mutationsCount: data?.client?.mutationLog?.count,
+            queriesCount: data?.client?.watchedQueries?.count ?? 0,
+            mutationsCount: data?.client?.mutationLog?.count ?? 0,
           }}
           embeddedExplorerProps={{
             embeddedExplorerIFrame,

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -6,6 +6,7 @@ import { Queries } from "./components/Queries/Queries";
 import { Mutations } from "./components/Mutations/Mutations";
 import { Explorer } from "./components/Explorer/Explorer";
 import { Cache } from "./components/Cache/Cache";
+import { clients, currentClient } from ".";
 
 export const reloadStatus = makeVar<boolean>(false);
 
@@ -16,19 +17,35 @@ const screens = {
   [Screens.Cache]: Cache,
 };
 
-const GET_OPERATION_COUNTS = gql`
-  query GetOperationCounts {
-    watchedQueries @client {
-      count
-    }
-    mutationLog @client {
-      count
+export const GET_OPERATION_COUNTS = gql`
+  query GetOperationCounts($clientId: ID!) {
+    client(id: $id) @client {
+      watchedQueries {
+        queries {
+          id
+        }
+        count
+      }
+      mutationLog {
+        count
+      }
     }
   }
 `;
 
 export const App = (): JSX.Element => {
-  const { data } = useQuery(GET_OPERATION_COUNTS);
+  const selectedClient = useReactiveVar(currentClient)
+  const allClients = useReactiveVar(clients);
+
+  if (allClients.length > 0 && !selectedClient) {
+    currentClient(allClients[0])
+  }
+
+  const { data } = useQuery(GET_OPERATION_COUNTS, {
+    variables: {
+      id: selectedClient
+    },
+  });
   const selected = useReactiveVar<Screens>(currentScreen);
   const reloading = useReactiveVar<boolean>(reloadStatus);
   const [embeddedExplorerIFrame, setEmbeddedExplorerIFrame] = useState<HTMLIFrameElement | null>(null);
@@ -52,8 +69,8 @@ export const App = (): JSX.Element => {
         <Screen
           isVisible={undefined}
           navigationProps={{
-            queriesCount: data?.watchedQueries?.count,
-            mutationsCount: data?.mutationLog?.count,
+            queriesCount: data?.client?.watchedQueries?.count,
+            mutationsCount: data?.client?.mutationLog?.count,
           }}
           embeddedExplorerProps={{
             embeddedExplorerIFrame,
@@ -68,8 +85,8 @@ export const App = (): JSX.Element => {
       <Explorer
         isVisible={selected === Screens.Explorer}
         navigationProps={{
-          queriesCount: data?.watchedQueries?.count,
-          mutationsCount: data?.mutationLog?.count,
+          queriesCount: data?.client?.watchedQueries?.count,
+          mutationsCount: data?.client?.mutationLog?.count,
         }}
         embeddedExplorerProps={{
           embeddedExplorerIFrame,
@@ -79,3 +96,4 @@ export const App = (): JSX.Element => {
     </>
   );
 };
+

--- a/src/application/__tests__/App.test.tsx
+++ b/src/application/__tests__/App.test.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { waitFor } from "@testing-library/react";
 
 import { renderWithApolloClient } from "../utilities/testing/renderWithApolloClient";
-import { currentScreen, Screens } from "../components/Layouts/Navigation";
+import { currentScreen } from "../components/Layouts/Navigation";
 import { App, reloadStatus } from "../App";
+import { Screens } from "../components/Layouts/screens";
 
 jest.mock("../components/Queries/Queries", () => ({
   Queries: ({ navigationProps }) => (
@@ -37,7 +38,7 @@ describe("<App />", () => {
 
   test("after reload, renders the Queries screen", async () => {
     currentScreen(Screens.Mutations);
-    const { getByText, debug } = renderWithApolloClient(<App />);
+    const { getByText } = renderWithApolloClient(<App />);
     const element = getByText("Mutations (0)");
     expect(element).toBeInTheDocument();
     await waitFor(() => {

--- a/src/application/components/Cache/Cache.tsx
+++ b/src/application/components/Cache/Cache.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useState } from "react";
 import { jsx, css } from "@emotion/react";
-import { gql, useQuery } from "@apollo/client";
+import { gql, useQuery, useReactiveVar } from "@apollo/client";
 import { rem } from "polished";
 import { colors } from "@apollo/space-kit/colors";
 
@@ -11,6 +11,7 @@ import { Search } from "./sidebar/Search";
 import { EntityList } from "./sidebar/EntityList";
 import { EntityView } from "./main/EntityView";
 import { Loading } from "./common/Loading";
+import { currentClient } from "../..";
 
 const { Header, Sidebar, Main, Content } = SidebarLayout;
 
@@ -39,8 +40,10 @@ const noDataStyles = css`
 `;
 
 const GET_CACHE = gql`
-  query GetCache {
-    cache @client
+  query GetCache($clientId: ID!) {
+    client(id: $clientId) @client {
+      cache
+    }
   }
 `;
 
@@ -52,12 +55,17 @@ export function Cache({ navigationProps }: {
 }): jsx.JSX.Element {
   const [searchResults, setSearchResults] = useState({});
   const [cacheId, setCacheId] = useState<string>("ROOT_QUERY");
+  const selectedClient = useReactiveVar(currentClient);
 
-  const { loading, data } = useQuery(GET_CACHE);
+  const { loading, data } = useQuery(GET_CACHE, {
+    variables: {
+      clientId: selectedClient
+    }
+  });
 
   let parsedData: Record<string, any> = {};
-  if (!loading && data && data.cache) {
-    parsedData = JSON.parse(data.cache);
+  if (!loading && data && data?.client?.cache) {
+    parsedData = JSON.parse(data.client.cache);
   }
 
   const dataExists = parsedData && Object.keys(parsedData).length > 0;

--- a/src/application/components/Cache/__tests__/Cache.test.tsx
+++ b/src/application/components/Cache/__tests__/Cache.test.tsx
@@ -3,7 +3,7 @@ import { within, waitFor, fireEvent } from "@testing-library/react";
 
 import { Cache } from "../Cache";
 import { renderWithApolloClient } from "../../../utilities/testing/renderWithApolloClient";
-import { client, writeData } from "../../../index";
+import { client, currentClient, writeData } from "../../../index";
 
 const CACHE_DATA = {
   "Result:1": {
@@ -65,13 +65,18 @@ describe("Cache component tests", () => {
 
   describe("With cache data", () => {
     beforeEach(() => {
-      client.resetStore();
-
+      const clientId = "client-1";
+      currentClient(clientId);
       writeData({
+        id: clientId,
         queries: [],
         mutations: [],
         cache: JSON.stringify(CACHE_DATA),
       });
+    });
+
+    afterEach(() => {
+      client.resetStore();
     });
 
     it("should show list of root cache ids in the sidebar", () => {
@@ -122,7 +127,10 @@ describe("Cache component tests", () => {
     const selectedMainStyles = "background-color: yellow";
 
     beforeEach(() => {
+      const clientId = "client-1";
+      currentClient(clientId);
       writeData({
+        id: clientId,
         queries: [],
         mutations: [],
         cache: JSON.stringify(CACHE_DATA),

--- a/src/application/components/Layouts/Navigation.tsx
+++ b/src/application/components/Layouts/Navigation.tsx
@@ -7,13 +7,7 @@ import { rem } from "polished";
 import { colors } from "@apollo/space-kit/colors";
 import { ApolloLogo } from "@apollo/space-kit/icons/ApolloLogo";
 import { clients, currentClient } from "../..";
-
-export enum Screens {
-  Cache = "cache",
-  Queries = "queries",
-  Mutations = "mutations",
-  Explorer = "explorer",
-}
+import { Screens } from "./screens";
 
 type NavButtonProps = {
   isSelected: boolean;

--- a/src/application/components/Layouts/Navigation.tsx
+++ b/src/application/components/Layouts/Navigation.tsx
@@ -6,6 +6,7 @@ import { jsx, css } from "@emotion/react";
 import { rem } from "polished";
 import { colors } from "@apollo/space-kit/colors";
 import { ApolloLogo } from "@apollo/space-kit/icons/ApolloLogo";
+import { clients, currentClient } from "../..";
 
 export enum Screens {
   Cache = "cache",
@@ -101,8 +102,14 @@ export const Navigation: React.FC<NavigationProps> = ({
   mutationsCount,
 }) => {
   const selected = useReactiveVar<Screens>(currentScreen);
+  const allClients = useReactiveVar(clients)
+  const selectedClient = useReactiveVar(currentClient);
+
   const isSelected = (NavButton: Screens) => selected === NavButton;
   const onNavigate = (screen: Screens) => currentScreen(screen);
+  const handleClientChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    currentClient(event.target.value)
+  }
 
   return (
     <nav css={navigationStyles}>
@@ -149,6 +156,17 @@ export const Navigation: React.FC<NavigationProps> = ({
             Cache
           </NavButton>
         </li>
+        {allClients.length > 1 && (
+          <li>
+            <select value={selectedClient ?? allClients[0]} onChange={handleClientChange}>
+              {allClients.map((client) => (
+                <option value={client} key={client}>
+                  {client}
+                </option>
+              ))}
+            </select>
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/src/application/components/Layouts/screens.ts
+++ b/src/application/components/Layouts/screens.ts
@@ -1,0 +1,6 @@
+export enum Screens {
+  Cache = "cache",
+  Queries = "queries",
+  Mutations = "mutations",
+  Explorer = "explorer",
+}

--- a/src/application/components/Mutations/__tests__/Mutations.test.tsx
+++ b/src/application/components/Mutations/__tests__/Mutations.test.tsx
@@ -3,22 +3,27 @@ import { within, waitFor } from "@testing-library/react";
 import user from "@testing-library/user-event";
 
 import { renderWithApolloClient } from "../../../utilities/testing/renderWithApolloClient";
-import { client, GET_MUTATIONS } from "../../../index";
+import { client, currentClient, GET_MUTATIONS } from "../../../index";
 import { Mutations } from "../Mutations";
 
 jest.mock("../MutationViewer", () => ({
   MutationViewer: () => null,
 }));
 
+
+const clientId = "client-1";
+
 describe("<Mutations />", () => {
   const mutations = [
     {
       id: 0,
+      clientId,
       __typename: "Mutation",
       name: null,
     },
     {
       id: 1,
+      clientId,
       __typename: "Mutation",
       name: "AddColorToFavorites",
     },
@@ -34,14 +39,22 @@ describe("<Mutations />", () => {
   });
 
   test("queries render in the sidebar", async () => {
+    currentClient(clientId);
     client.writeQuery({
       query: GET_MUTATIONS,
       data: {
-        mutationLog: {
-          mutations,
-          count: mutations.length,
-        },
+        client: {
+          id: clientId,
+          __typename: "Client",
+          mutationLog: {
+            mutations,
+            count: mutations.length,
+          },
+        }
       },
+      variables: {
+        clientId
+      }
     });
 
     const { getByTestId } = renderWithApolloClient(
@@ -63,14 +76,22 @@ describe("<Mutations />", () => {
   });
 
   test("renders query name", async () => {
+    currentClient(clientId)
     client.writeQuery({
       query: GET_MUTATIONS,
       data: {
-        mutationLog: {
-          mutations,
-          count: mutations.length,
-        },
+        client: {
+          id: clientId,
+          __typename: "Client",
+          mutationLog: {
+            mutations,
+            count: mutations.length,
+          }
+        }
       },
+      variables: {
+        clientId
+      }
     });
 
     const { getByTestId } = renderWithApolloClient(

--- a/src/application/components/Queries/RunInExplorerButton.tsx
+++ b/src/application/components/Queries/RunInExplorerButton.tsx
@@ -7,7 +7,8 @@ import {
   postMessageToEmbed,
   SET_OPERATION,
 } from "../Explorer/postMessageHelpers";
-import { currentScreen, Screens } from "../Layouts/Navigation";
+import { currentScreen } from "../Layouts/Navigation";
+import { Screens } from "../Layouts/screens";
 
 interface RunInExplorerButtonProps {
   operation: string;

--- a/src/application/components/Queries/__tests__/Queries.test.tsx
+++ b/src/application/components/Queries/__tests__/Queries.test.tsx
@@ -3,23 +3,27 @@ import { within, waitFor } from "@testing-library/react";
 import user from "@testing-library/user-event";
 
 import { renderWithApolloClient } from "../../../utilities/testing/renderWithApolloClient";
-import { client, GET_QUERIES } from "../../../index";
+import { client, currentClient, GET_QUERIES } from "../../../index";
 import { Queries } from "../Queries";
 
 jest.mock("../QueryViewer", () => ({
   QueryViewer: () => null,
 }));
 
+const clientId = "client-1";
+
 describe("<Queries />", () => {
   const queries = [
     {
       id: 0,
       __typename: "WatchedQuery",
+      clientId,
       name: null,
     },
     {
       id: 1,
       __typename: "WatchedQuery",
+      clientId,
       name: "GetColors",
     },
   ];
@@ -34,13 +38,21 @@ describe("<Queries />", () => {
   });
 
   test("queries render in the sidebar", async () => {
+    currentClient(clientId);
     client.writeQuery({
       query: GET_QUERIES,
       data: {
-        watchedQueries: {
-          queries,
-          count: queries.length,
+        client: {
+          id: clientId,
+          __typename: "Client",
+          watchedQueries: {
+            queries,
+            count: queries.length,
+          },
         },
+      },
+      variables: {
+        clientId,
       },
     });
 
@@ -61,13 +73,21 @@ describe("<Queries />", () => {
   });
 
   test("renders query name", async () => {
+    currentClient(clientId);
     client.writeQuery({
       query: GET_QUERIES,
       data: {
-        watchedQueries: {
-          queries,
-          count: queries.length,
+        client: {
+          id: clientId,
+          __typename: "Client",
+          watchedQueries: {
+            queries,
+            count: queries.length,
+          },
         },
+      },
+      variables: {
+        clientId,
       },
     });
 

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -20,23 +20,33 @@ import { App, reloadStatus } from "./App";
 
 import "@apollo/space-kit/reset.css";
 
-const cache = new InMemoryCache({
+const queryCacheMap = new Map();
+
+const inMemoryCache = new InMemoryCache({
   typePolicies: {
     WatchedQuery: {
+      keyFields: ["id", "clientId"],
       fields: {
         name(_) {
           return _ ?? "Unnamed";
         },
+        clientId(_) {
+          return _
+        }
       },
     },
     Mutation: {
+      keyFields: ["id", "clientId"],
       fields: {
         name(_) {
           return _ ?? "Unnamed";
         },
+        clientId(_) {
+          return _
+        }
       },
     },
-    Query: {
+    Client: {
       fields: {
         watchedQueries(_ = { queries: [], count: 0 }) {
           return _;
@@ -44,56 +54,74 @@ const cache = new InMemoryCache({
         mutationLog(_ = { mutations: [], count: 0 }) {
           return _;
         },
-        watchedQuery(_, { toReference, args, canRead }) {
+        watchedQuery(_, { toReference, variables, canRead }) {
           const ref = toReference({
             __typename: "WatchedQuery",
-            id: args?.id,
+            id: variables?.id,
+            clientId: variables?.clientId
           });
 
           return canRead(ref) ? ref : _;
         },
-        mutation(_, { toReference, args }) {
+        mutation(_, { toReference, variables }) {
           return toReference({
             __typename: "Mutation",
-            id: args?.id,
+            id: variables?.id,
+            clientId: variables?.clientId
           });
         },
-        cache() {
-          return cacheVar();
+        cache(_, { variables }) {
+          const cacheVar = queryCacheMap.get(variables?.clientId);
+          return cacheVar && cacheVar()
+        },
+      }
+    },
+    Query: {
+      fields: {
+        client: {
+          read(_) {
+            return _
+          }
         },
       },
     },
   },
 });
 
-const cacheVar = makeVar(null);
 export const client = new ApolloClient({
-  cache,
+  cache: inMemoryCache,
 });
 
+
 export const GET_QUERIES = gql`
-  query GetQueries {
-    watchedQueries @client {
-      queries {
-        name
-        queryString
-        variables
-        cachedData
+  query GetQueries($clientId: ID!) {
+    client(id: $clientId) @client {
+      watchedQueries {
+        queries {
+          name
+          clientId
+          queryString
+          variables
+          cachedData
+        }
+        count
       }
-      count
     }
   }
 `;
 
 export const GET_MUTATIONS = gql`
-  query GetMutations {
-    mutationLog @client {
-      mutations {
-        name
-        mutationString
-        variables
+  query GetMutations($clientId: ID!) {
+    client(id: $clientId) @client {
+      mutationLog {
+        mutations {
+          name
+          clientId
+          mutationString
+          variables
+        }
+        count
       }
-      count
     }
   }
 `;
@@ -147,36 +175,76 @@ export function getMutationData(mutation, key: number): Mutation | undefined {
   };
 }
 
-export const writeData = ({ queries, mutations, cache }) => {
+export const clients = makeVar<string[]>([])
+export const currentClient = makeVar<string | null>(null);
+
+export const writeData = ({ id, queries, mutations, cache }) => {
+  const registeredClients = clients();
+  if (!registeredClients.includes(id)) {
+    clients([...registeredClients, id])
+  }
+
   const filteredQueries: WatchedQuery[] = queries
     .map((q, i: number) => getQueryData(q, i))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(data => {
+      return { ...data, clientId: id }
+    })
 
   client.writeQuery({
     query: GET_QUERIES,
     data: {
-      watchedQueries: {
-        queries: filteredQueries,
-        count: filteredQueries.length,
-      },
+      client: {
+        id: id,
+        __typename: "Client",
+        watchedQueries: {
+          queries: filteredQueries,
+          count: filteredQueries.length,
+        },
+      }
     },
+    variables: {
+      clientId: id
+    }
   });
 
   const mappedMutations: Mutation[] = mutations.map((m, i: number) =>
     getMutationData(m, i)
-  );
+  )
+  .filter(Boolean)
+  .map(data => {
+    return { ...data, clientId: id }
+  })
+
 
   client.writeQuery({
     query: GET_MUTATIONS,
     data: {
-      mutationLog: {
-        mutations: mappedMutations,
-        count: mappedMutations.length,
-      },
+      client: {
+        id,
+        __typename: "Client",
+        mutationLog: {
+          mutations: mappedMutations,
+          count: mappedMutations.length,
+        },
+      }
     },
+    variables: {
+      clientId: id
+    }
   });
+
+  const cacheVar = queryCacheMap.get(id) ?? makeVar(null);
   cacheVar(cache);
+  queryCacheMap.set(id, cacheVar)
 };
+
+const reset = () => {
+  clients([])
+  currentClient(null)
+  queryCacheMap.clear();
+  client.resetStore();
+}
 
 export const handleReload = () => {
   reloadStatus(true);
@@ -184,7 +252,7 @@ export const handleReload = () => {
 
 export const handleReloadComplete = () => {
   reloadStatus(false);
-  client.resetStore();
+  reset();
 };
 
 export const AppProvider = () => {

--- a/src/extension/background/background.ts
+++ b/src/extension/background/background.ts
@@ -1,6 +1,6 @@
 import Relay from '../../Relay';
-import { 
-  REQUEST_TAB_ID, 
+import {
+  REQUEST_TAB_ID,
 } from '../constants';
 
 // This sends the tab id to the inspected tab.
@@ -14,9 +14,18 @@ const background = new Relay();
 
 chrome.runtime.onConnect.addListener(port => {
   background.addConnection(port.name, message => {
-    port.postMessage(message);
+    try {
+      port.postMessage(message);
+    } catch {
+      /*
+      * With multiple frames, we receive a onDisconnect event twice,
+      * resulting in stale ports. Without the try/catch, we drop
+      * legitimate messages as well.
+      */
+      console.error('Error sending message to ' + port.name)
+    }
   });
-  
+
   port.onMessage.addListener(message => {
     background.broadcast(message);
   });

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -56,7 +56,7 @@ devtools.listen(CREATE_DEVTOOLS_PANEL, ({ payload }) => {
       "panel.html",
       function (panel) {
         isPanelCreated = true;
-        const { queries, mutations, cache } = JSON.parse(payload);
+        const { id, queries, mutations, cache } = JSON.parse(payload);
         let removeUpdateListener;
         let removeExplorerForward;
         let removeSubscriptionTerminationListener;
@@ -81,15 +81,15 @@ devtools.listen(CREATE_DEVTOOLS_PANEL, ({ payload }) => {
 
           if (!isAppInitialized) {
             initialize();
-            writeData({ queries, mutations, cache: JSON.stringify(cache) });
+            writeData({ id, queries, mutations, cache: JSON.stringify(cache) });
             isAppInitialized = true;
           }
 
           clearRequestInterval = startRequestInterval();
 
           removeUpdateListener = devtools.listen(UPDATE, ({ payload }) => {
-            const { queries, mutations, cache } = JSON.parse(payload);
-            writeData({ queries, mutations, cache: JSON.stringify(cache) });
+            const { id, queries, mutations, cache } = JSON.parse(payload);
+            writeData({ id, queries, mutations, cache: JSON.stringify(cache) });
           });
 
           // Add connection so client can send to `background:devtools-${inspectedTabId}:explorer`

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -19,7 +19,8 @@
     {
       "matches": ["<all_urls>"],
       "js": ["tab.js"],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "manifest_version": 2

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -6,7 +6,7 @@ import { ApolloClient, ApolloError, NetworkStatus } from "@apollo/client";
 import gql from "graphql-tag";
 import Observable from "zen-observable";
 import { OperationDefinitionNode } from "graphql/language";
-
+import cuid from "cuid"
 import { version as devtoolsVersion } from "../manifest.json";
 import Relay from "../../Relay";
 import {
@@ -46,6 +46,8 @@ type Hook = {
   getMutations: () => QueryInfo[];
   getCache: () => void;
 };
+
+const apolloClientId = cuid();
 
 function initializeHook() {
   const hook: Hook = {
@@ -105,6 +107,7 @@ function initializeHook() {
     sendMessageToTab(
       eventName,
       JSON.stringify({
+        id: apolloClientId,
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
         cache: hook.getCache(),


### PR DESCRIPTION
Per discussion [here](https://github.com/apollographql/apollo-client-devtools/discussions/380), I've been hacking around trying to get iframe support up and running.

### What works (with multiple iframes on a page)

- Inspecting Queries 
- Inspecting Mutations
- Cache Explorer

### What's pending

- [ ] Explorer: I haven't figured out a way to get it to use the correct Apollo Client yet. It always prefers the window. Perhaps this could be a separate PR to keep scope in check.
- [ ] Generating a better ID for windows and iframes. Currently using a cuid, but this should ideally be something intelligible like the native browser frame selector. Work is also needed on UX here.
- [ ] Removing stale iframes from the list if they dismount: I don't know what it is, but emitting a postMessage on `onunload`/`pagehide` doesn't seem to be picked up 🤷‍♀️. I guess we can just let them remain in the list, but it would be nice if it auto-updates. Convoluted solutions with beacons might be possible, but the cost/benefit doesn't make sense.
- [x] Fix existing tests
- [ ] More coverage for new functionality

### Demo

I have the test app running, and another create-react-app with a single query running in a setInterval to simulate two clients running on different frames. Here's a video:

https://user-images.githubusercontent.com/8260207/208457477-6661b9c1-cc71-4dc6-811f-c645a4de4e15.mp4

I also tried out a sample app on Codesandbox and it seems to work fine. Note that sometimes CodeSandbox may take [more than 10 seconds](https://github.com/apollographql/apollo-client-devtools/blob/285df192fe0b57b0b09552291e1577b89dbbbb3a/src/extension/tab/hook.ts#L218) to initialise, and the connection won't be established in those cases. 

Since this has turned into a relatively large refactor, I'd like to get some early feedback on the work. CC: @bignimbus @jpvajda @MrDoomBringer (apologies for the direct tag, didn't find a better way to page maintainers)
