### PR TITLE
Use `browser` namespace with `webextension-polyfill` instead of `chrome` namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "typescript": "4.9.5",
         "web-ext": "7.5.0",
         "web-ext-plugin": "2.7.0",
+        "webextension-polyfill": "^0.10.0",
         "webpack": "5.75.0",
         "webpack-cli": "4.10.0"
       }
@@ -18234,6 +18235,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
+      "dev": true
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -32813,6 +32820,12 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/jest": "26.0.24",
         "@types/react": "17.0.53",
         "@types/react-dom": "17.0.19",
+        "@types/webextension-polyfill": "^0.10.0",
         "@typescript-eslint/eslint-plugin": "5.54.0",
         "@typescript-eslint/parser": "5.54.0",
         "copy-webpack-plugin": "7.0.0",
@@ -3704,6 +3705,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-If4EcaHzYTqcbNMp/FdReVdRmLL/Te42ivnJII551bYjhX19bWem5m14FERCqdJA732OloGuxCRvLBvcMGsn4A==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -21918,6 +21925,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
+    },
+    "@types/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-If4EcaHzYTqcbNMp/FdReVdRmLL/Te42ivnJII551bYjhX19bWem5m14FERCqdJA732OloGuxCRvLBvcMGsn4A==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "typescript": "4.9.5",
     "web-ext": "7.5.0",
     "web-ext-plugin": "2.7.0",
+    "webextension-polyfill": "^0.10.0",
     "webpack": "5.75.0",
     "webpack-cli": "4.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/jest": "26.0.24",
     "@types/react": "17.0.53",
     "@types/react-dom": "17.0.19",
+    "@types/webextension-polyfill": "^0.10.0",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",
     "copy-webpack-plugin": "7.0.0",

--- a/src/extension/background/background.ts
+++ b/src/extension/background/background.ts
@@ -2,17 +2,18 @@ import Relay from '../../Relay';
 import { 
   REQUEST_TAB_ID, 
 } from '../constants';
+import browser from 'webextension-polyfill';
 
 // This sends the tab id to the inspected tab.
-chrome.runtime.onMessage.addListener(({ message }, sender, sendResponse) => {
+browser.runtime.onMessage.addListener(({ message }, sender) => {
   if (message === REQUEST_TAB_ID) {
-    sendResponse(sender?.tab?.id);
+    return Promise.resolve(sender.tab?.id);
   }
 });
 
 const background = new Relay();
 
-chrome.runtime.onConnect.addListener(port => {
+browser.runtime.onConnect.addListener(port => {
   background.addConnection(port.name, message => {
     port.postMessage(message);
   });

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -11,11 +11,12 @@ import {
   RELOADING_TAB,
   RELOAD_TAB_COMPLETE,
 } from "../constants";
+import browser from 'webextension-polyfill'
 
-const inspectedTabId = chrome.devtools.inspectedWindow.tabId;
+const inspectedTabId = browser.devtools.inspectedWindow.tabId;
 const devtools = new Relay();
 
-const port = chrome.runtime.connect({
+const port = browser.runtime.connect({
   name: `devtools-${inspectedTabId}`,
 });
 port.onMessage.addListener(devtools.broadcast);
@@ -48,93 +49,92 @@ devtools.addConnection(EXPLORER_SUBSCRIPTION_TERMINATION, () => {
   sendMessageToClient(EXPLORER_SUBSCRIPTION_TERMINATION);
 });
 
-devtools.listen(CREATE_DEVTOOLS_PANEL, ({ payload }) => {
+devtools.listen(CREATE_DEVTOOLS_PANEL, async ({ payload }) => {
   if (!isPanelCreated) {
-    chrome.devtools.panels.create(
+    const panel = await browser.devtools.panels.create(
       "Apollo",
       "logo_devtools.png",
       "panel.html",
-      function (panel) {
-        isPanelCreated = true;
-        const { queries, mutations, cache } = JSON.parse(payload);
-        let removeUpdateListener;
-        let removeExplorerForward;
-        let removeSubscriptionTerminationListener;
-        let removeReloadListener;
-        let clearRequestInterval;
-        let removeExplorerListener;
-
-        panel.onShown.addListener((window) => {
-          sendMessageToClient(PANEL_OPEN);
-
-          const {
-            __DEVTOOLS_APPLICATION__: {
-              initialize,
-              writeData,
-              receiveExplorerRequests,
-              receiveSubscriptionTerminationRequest,
-              sendResponseToExplorer,
-              handleReload,
-              handleReloadComplete,
-            },
-          } = window as any;
-
-          if (!isAppInitialized) {
-            initialize();
-            writeData({ queries, mutations, cache: JSON.stringify(cache) });
-            isAppInitialized = true;
-          }
-
-          clearRequestInterval = startRequestInterval();
-
-          removeUpdateListener = devtools.listen(UPDATE, ({ payload }) => {
-            const { queries, mutations, cache } = JSON.parse(payload);
-            writeData({ queries, mutations, cache: JSON.stringify(cache) });
-          });
-
-          // Add connection so client can send to `background:devtools-${inspectedTabId}:explorer`
-          devtools.addConnection("explorer", sendResponseToExplorer);
-          removeExplorerListener = receiveExplorerRequests(({ detail }) => {
-            devtools.broadcast(detail);
-          });
-
-          removeSubscriptionTerminationListener =
-            receiveSubscriptionTerminationRequest(({ detail }) => {
-              devtools.broadcast(detail);
-            });
-
-          // Forward all Explorer requests to the client
-          removeExplorerForward = devtools.forward(
-            EXPLORER_REQUEST,
-            `background:tab-${inspectedTabId}:client`
-          );
-
-          // Listen for tab reload from background
-          removeReloadListener = devtools.listen(RELOADING_TAB, () => {
-            handleReload();
-            clearRequestInterval();
-
-            const removeListener = devtools.listen(RELOAD_TAB_COMPLETE, () => {
-              clearRequestInterval = startRequestInterval();
-              handleReloadComplete();
-              removeListener();
-            });
-          });
-        });
-
-        panel.onHidden.addListener(() => {
-          isPanelCreated = false;
-          clearRequestInterval();
-          removeExplorerForward();
-          removeSubscriptionTerminationListener();
-          removeUpdateListener();
-          removeReloadListener();
-          removeExplorerListener();
-          devtools.removeConnection("explorer");
-          sendMessageToClient(PANEL_CLOSED);
-        });
-      }
     );
+
+    isPanelCreated = true;
+    const { queries, mutations, cache } = JSON.parse(payload);
+    let removeUpdateListener;
+    let removeExplorerForward;
+    let removeSubscriptionTerminationListener;
+    let removeReloadListener;
+    let clearRequestInterval;
+    let removeExplorerListener;
+
+    panel.onShown.addListener((window) => {
+      sendMessageToClient(PANEL_OPEN);
+
+      const {
+        __DEVTOOLS_APPLICATION__: {
+          initialize,
+          writeData,
+          receiveExplorerRequests,
+          receiveSubscriptionTerminationRequest,
+          sendResponseToExplorer,
+          handleReload,
+          handleReloadComplete,
+        },
+      } = window as any;
+
+      if (!isAppInitialized) {
+        initialize();
+        writeData({ queries, mutations, cache: JSON.stringify(cache) });
+        isAppInitialized = true;
+      }
+
+      clearRequestInterval = startRequestInterval();
+
+      removeUpdateListener = devtools.listen(UPDATE, ({ payload }) => {
+        const { queries, mutations, cache } = JSON.parse(payload);
+        writeData({ queries, mutations, cache: JSON.stringify(cache) });
+      });
+
+      // Add connection so client can send to `background:devtools-${inspectedTabId}:explorer`
+      devtools.addConnection("explorer", sendResponseToExplorer);
+      removeExplorerListener = receiveExplorerRequests(({ detail }) => {
+        devtools.broadcast(detail);
+      });
+
+      removeSubscriptionTerminationListener =
+        receiveSubscriptionTerminationRequest(({ detail }) => {
+          devtools.broadcast(detail);
+        });
+
+      // Forward all Explorer requests to the client
+      removeExplorerForward = devtools.forward(
+        EXPLORER_REQUEST,
+        `background:tab-${inspectedTabId}:client`
+      );
+
+      // Listen for tab reload from background
+      removeReloadListener = devtools.listen(RELOADING_TAB, () => {
+        handleReload();
+        clearRequestInterval();
+
+        const removeListener = devtools.listen(RELOAD_TAB_COMPLETE, () => {
+          clearRequestInterval = startRequestInterval();
+          handleReloadComplete();
+          removeListener();
+        });
+      });
+    });
+
+    panel.onHidden.addListener(() => {
+      isPanelCreated = false;
+      clearRequestInterval();
+      removeExplorerForward();
+      removeSubscriptionTerminationListener();
+      removeUpdateListener();
+      removeReloadListener();
+      removeExplorerListener();
+      devtools.removeConnection("explorer");
+      sendMessageToClient(PANEL_CLOSED);
+    });
   }
 });
 

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -1,5 +1,6 @@
 // This script is injected into each tab.
 import "./tabRelay"; 
+import browser from 'webextension-polyfill';
 
 /* 
   Content scripts are unable to modify the window object directly. 
@@ -9,7 +10,7 @@ import "./tabRelay";
 if (typeof document === "object" && document instanceof HTMLDocument) {
   const script = document.createElement("script");
   script.setAttribute("type", "module");
-  script.setAttribute("src", chrome.extension.getURL("hook.js"));
+  script.setAttribute("src", browser.runtime.getURL("hook.js"));
   document.addEventListener("DOMContentLoaded", () => {
     const importMap = document.querySelector("script[type=\"importmap\"]");
     if (importMap != null) {

--- a/src/extension/tab/tabRelay.ts
+++ b/src/extension/tab/tabRelay.ts
@@ -9,22 +9,19 @@ import {
   RELOADING_TAB,
   RELOAD_TAB_COMPLETE,
 } from "../constants";
+import browser from 'webextension-polyfill';
 
 // Inspected tabs are unable to retrieve their own ids.
 // This requests the tab's id from the background script.
 // Once it resolves, we can create the tab's Relay.
 function requestId() {
-  return new Promise((resolve) => {
-    chrome.runtime.sendMessage({ message: REQUEST_TAB_ID }, function (id) {
-      resolve(id);
-    });
-  });
+  return browser.runtime.sendMessage({ message: REQUEST_TAB_ID });
 }
 
 export default new Promise(async ($export) => {
   const id = await requestId();
   const tab = new Relay();
-  const port = chrome.runtime.connect({
+  const port = browser.runtime.connect({
     name: `tab-${id}`,
   });
 


### PR DESCRIPTION
`browser` is the [proposed standard](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension) for building cross-browser extensions, which also supports the use of promises instead of callbacks for async APIs. Our extension currently uses the `chrome` namespace for interaction in our extension. While this has always worked in both Firefox and Chrome, `browser` will be the future supported API. 

This PR updates the use of `chrome` APIs to use `browser` by installing the [`webextension-polyfill`](https://github.com/mozilla/webextension-polyfill) to provide compatibility with Chrome.