### PR TITLE
Improve cache search

### DIFF
--- a/.changeset/eight-ants-decide.md
+++ b/.changeset/eight-ants-decide.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Improve searching the cache by filtering the list of cache ids that match the search term and highlight the matched substring. This change removes the matching against the cache values as that was difficult to determine why a match occurred.

--- a/src/application/components/Cache/Cache.tsx
+++ b/src/application/components/Cache/Cache.tsx
@@ -70,7 +70,6 @@ export function Cache({
   };
 }): JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
-  const [searchResults] = useState<Record<string, JSONObject>>({});
   const [cacheId, setCacheId] = useState("ROOT_QUERY");
 
   const { loading, data } = useQuery(GET_CACHE);
@@ -120,7 +119,6 @@ export function Cache({
             <EntityView
               cacheId={cacheId}
               data={cache[cacheId]}
-              searchResults={searchResults}
               setCacheId={setCacheId}
             />
           )}

--- a/src/application/components/Cache/Cache.tsx
+++ b/src/application/components/Cache/Cache.tsx
@@ -97,6 +97,7 @@ export function Cache({
               data={filteredCache}
               selectedCacheId={cacheId}
               setCacheId={setCacheId}
+              searchTerm={searchTerm}
             />
           </Fragment>
         ) : (

--- a/src/application/components/Cache/Cache.tsx
+++ b/src/application/components/Cache/Cache.tsx
@@ -95,7 +95,7 @@ export function Cache({
             <Search onChange={setSearchTerm} value={searchTerm} />
             <EntityList
               data={filteredCache}
-              cacheId={cacheId}
+              selectedCacheId={cacheId}
               setCacheId={setCacheId}
             />
           </Fragment>

--- a/src/application/components/Cache/Cache.tsx
+++ b/src/application/components/Cache/Cache.tsx
@@ -98,7 +98,6 @@ export function Cache({
               data={filteredCache}
               cacheId={cacheId}
               setCacheId={setCacheId}
-              searchResults={searchResults}
             />
           </Fragment>
         ) : (

--- a/src/application/components/Cache/__tests__/Cache.test.tsx
+++ b/src/application/components/Cache/__tests__/Cache.test.tsx
@@ -7,6 +7,7 @@ import {
   act,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { colors } from "@apollo/space-kit/colors";
 
 import { Cache } from "../Cache";
 import { renderWithApolloClient } from "../../../utilities/testing/renderWithApolloClient";
@@ -133,7 +134,7 @@ describe("Cache component tests", () => {
       });
     });
 
-    it("should highlight sidebar cache ID's if a match is found", async () => {
+    it("filters cache ID's for matches against the keyword", async () => {
       const user = userEvent.setup();
       renderWithApolloClient(<Cache navigationProps={navigationProps} />);
 
@@ -160,8 +161,8 @@ describe("Cache component tests", () => {
       expect(within(sidebar).queryByText("ROOT_QUERY")).not.toBeInTheDocument();
     });
 
-    it("should highlight object keys/values if a match is found", async () => {
-      const selectedMainStyles = "background-color: yellow";
+    it("highlights matched substring in cache ID", async () => {
+      const selectedMainStyles = `background: ${colors.yellow.base}`;
       const user = userEvent.setup();
 
       renderWithApolloClient(<Cache navigationProps={navigationProps} />);
@@ -171,22 +172,20 @@ describe("Cache component tests", () => {
 
       const sidebar = screen.getByTestId("sidebar");
 
-      const result2 = within(sidebar).getByText("Result:2");
-      const result2Parent = result2.parentNode;
-      fireEvent.click(result2Parent!);
-
-      const main = screen.getByTestId("main");
-
-      await waitFor(() => {
-        expect(within(main).getByText("__typename:")).not.toHaveStyle(
-          selectedMainStyles
-        );
+      const result1 = within(sidebar).getByText((_, element) => {
+        return elementMatchesHighlightedNode(element, "Result:1");
       });
-      expect(within(main).getByText('"Result"')).not.toHaveStyle(
+
+      const result2 = within(sidebar).getByText((_, element) => {
+        return elementMatchesHighlightedNode(element, "Result:2");
+      });
+
+      expect(within(result1).getByText("Res")).toHaveStyle(selectedMainStyles);
+      expect(within(result1).getByText("ult:1")).not.toHaveStyle(
         selectedMainStyles
       );
-      expect(within(main).getByText("name:")).toHaveStyle(selectedMainStyles);
-      expect(within(main).getByText('"Result 2"')).toHaveStyle(
+      expect(within(result2).getByText("Res")).toHaveStyle(selectedMainStyles);
+      expect(within(result2).getByText("ult:2")).not.toHaveStyle(
         selectedMainStyles
       );
     });

--- a/src/application/components/Cache/common/__tests__/utils.test.ts
+++ b/src/application/components/Cache/common/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getRootCacheIds, objectFilter } from "../utils";
+import { getRootCacheIds } from "../utils";
 
 describe("Utility tests", () => {
   describe("#getRootCacheIds", () => {
@@ -68,87 +68,6 @@ describe("Utility tests", () => {
       expect(cacheIds[1]).toEqual("ROOT_MUTATION");
       expect(cacheIds[2]).toEqual("ROOT_SUBSCRIPTION");
       expect(cacheIds[3]).toEqual("Result:1");
-    });
-  });
-
-  describe("#objectFilter", () => {
-    it("should return a new object with key/value pair if matching key found", () => {
-      const car = {
-        make: "Ford",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "make")).toEqual({
-        make: "Ford",
-      });
-    });
-
-    it("should return a new object with key/value pair if partial matching key found", () => {
-      const car = {
-        make: "Ford",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "ma")).toEqual({
-        make: "Ford",
-      });
-    });
-
-    it("should return a new object with key/value pair if matching string value found", () => {
-      const car = {
-        make: "Ford",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "Ford")).toEqual({
-        make: "Ford",
-      });
-    });
-
-    it("should return a new object with key/value pair if partial matching string value found", () => {
-      const car = {
-        make: "Ford",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "Fo")).toEqual({
-        make: "Ford",
-      });
-    });
-
-    it("should return all key/value pair matches in a new object", () => {
-      const car = {
-        makeName: "Ford",
-        makeId: "FRD010",
-      };
-      expect(objectFilter(car, "make")).toEqual({
-        makeName: "Ford",
-        makeId: "FRD010",
-      });
-    });
-
-    it("should return key/value matches using case insensitivity", () => {
-      const car = {
-        make: "FORD",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "ford")).toEqual({
-        make: "FORD",
-      });
-    });
-
-    it("should return undefined if no matching key/value is found", () => {
-      const car = {
-        make: "Ford",
-        model: "Pinto",
-      };
-      expect(objectFilter(car, "vin")).toBeUndefined();
-    });
-
-    it("should exclude nested objects", () => {
-      const car = {
-        make: "Ford",
-        model: {
-          id: "Pinto",
-        },
-      };
-      expect(objectFilter(car, "Pinto")).toBeUndefined();
     });
   });
 });

--- a/src/application/components/Cache/common/utils.ts
+++ b/src/application/components/Cache/common/utils.ts
@@ -17,22 +17,3 @@ export function getRootCacheIds(data: JSONObject = {}) {
 
   return [...sortedRootIds, ...sortedNonRootIds];
 }
-
-// Filter the passed in object, returning a new object that has any keys or
-// values that match the specified keywords. Object values are only matched
-// if they are strings, all matching is case insensitive, and only top
-// level values are checked (nested objects are skipped).
-export function objectFilter(data: JSONObject, keywords: string) {
-  let results: JSONObject | undefined;
-  const regex = new RegExp(keywords, "i");
-  Object.keys(data).forEach((key) => {
-    const value = data[key];
-    const keyMatch = regex.test(key);
-    const valueMatch = typeof value === "string" && regex.test(value);
-    if (keyMatch || valueMatch) {
-      if (results === undefined) results = {};
-      results[key] = value;
-    }
-  });
-  return results;
-}

--- a/src/application/components/Cache/main/EntityView.tsx
+++ b/src/application/components/Cache/main/EntityView.tsx
@@ -36,9 +36,6 @@ export function EntityView({ cacheId, data, setCacheId }: EntityViewProps) {
         theme={treeTheme}
         invertTheme={false}
         hideRoot={true}
-        labelRenderer={([key]) => {
-          return <span>{key}:</span>;
-        }}
         valueRenderer={(valueAsString: ReactNode, value, key) => {
           return (
             <span

--- a/src/application/components/Cache/main/EntityView.tsx
+++ b/src/application/components/Cache/main/EntityView.tsx
@@ -17,28 +17,17 @@ const cacheStyles = css`
   }
 `;
 
-const selectedStyles = css`
-  background-color: yellow;
-`;
-
 interface EntityViewProps {
   cacheId: string;
   data: JSONObject | undefined;
-  searchResults: Record<string, JSONObject>;
   setCacheId: (cacheId: string) => void;
 }
 
-export function EntityView({
-  cacheId,
-  data,
-  searchResults,
-  setCacheId,
-}: EntityViewProps) {
+export function EntityView({ cacheId, data, setCacheId }: EntityViewProps) {
   const treeTheme = useTreeTheme();
 
   if (!data) return null;
 
-  const searchResult = searchResults[cacheId];
   return (
     <div css={cacheStyles}>
       {cacheId}
@@ -48,16 +37,12 @@ export function EntityView({
         invertTheme={false}
         hideRoot={true}
         labelRenderer={([key]) => {
-          const matchFound = searchResult && !!searchResult[key];
-          return <span css={matchFound ? selectedStyles : void 0}>{key}:</span>;
+          return <span>{key}:</span>;
         }}
         valueRenderer={(valueAsString: ReactNode, value, key) => {
-          const matchFound = searchResult && searchResult[key] === value;
-
           return (
             <span
               css={css`
-                ${matchFound ? selectedStyles : void 0}
                 ${key === "__ref" &&
                 css`
                   &:hover {

--- a/src/application/components/Cache/sidebar/EntityList.tsx
+++ b/src/application/components/Cache/sidebar/EntityList.tsx
@@ -38,14 +38,14 @@ export function EntityList({
       selectedColor={theme.sidebarSelected}
       hoverColor={theme.sidebarHover}
     >
-      {ids.map((listCacheId, index) => {
+      {ids.map((cacheId) => {
         return (
           <ListItem
-            key={`${listCacheId}-${index}`}
-            onClick={() => setCacheId(listCacheId)}
-            selected={listCacheId === selectedCacheId}
+            key={cacheId}
+            onClick={() => setCacheId(cacheId)}
+            selected={cacheId === selectedCacheId}
           >
-            {listCacheId}
+            {cacheId}
           </ListItem>
         );
       })}

--- a/src/application/components/Cache/sidebar/EntityList.tsx
+++ b/src/application/components/Cache/sidebar/EntityList.tsx
@@ -22,18 +22,12 @@ interface EntityListProps {
   data: Record<string, JSONObject>;
   cacheId: string;
   setCacheId: (cacheId: string) => void;
-  searchResults: Record<string, JSONObject>;
 }
 
-export function EntityList({
-  data,
-  cacheId,
-  setCacheId,
-  searchResults = {},
-}: EntityListProps) {
+export function EntityList({ data, cacheId, setCacheId }: EntityListProps) {
   const theme = useTheme();
   const ids = getRootCacheIds(data);
-  const idHits = Object.keys(searchResults);
+
   return (
     <List
       css={listStyles}
@@ -46,7 +40,6 @@ export function EntityList({
             key={`${listCacheId}-${index}`}
             onClick={() => setCacheId(listCacheId)}
             selected={listCacheId === cacheId}
-            highlighted={idHits.includes(listCacheId)}
           >
             {listCacheId}
           </ListItem>

--- a/src/application/components/Cache/sidebar/EntityList.tsx
+++ b/src/application/components/Cache/sidebar/EntityList.tsx
@@ -20,11 +20,15 @@ const listStyles = css`
 
 interface EntityListProps {
   data: Record<string, JSONObject>;
-  cacheId: string;
+  selectedCacheId: string;
   setCacheId: (cacheId: string) => void;
 }
 
-export function EntityList({ data, cacheId, setCacheId }: EntityListProps) {
+export function EntityList({
+  data,
+  selectedCacheId,
+  setCacheId,
+}: EntityListProps) {
   const theme = useTheme();
   const ids = getRootCacheIds(data);
 
@@ -39,7 +43,7 @@ export function EntityList({ data, cacheId, setCacheId }: EntityListProps) {
           <ListItem
             key={`${listCacheId}-${index}`}
             onClick={() => setCacheId(listCacheId)}
-            selected={listCacheId === cacheId}
+            selected={listCacheId === selectedCacheId}
           >
             {listCacheId}
           </ListItem>

--- a/src/application/components/Cache/sidebar/EntityList.tsx
+++ b/src/application/components/Cache/sidebar/EntityList.tsx
@@ -7,6 +7,7 @@ import { rem } from "polished";
 import { useTheme } from "../../../theme";
 import { getRootCacheIds } from "../common/utils";
 import { JSONObject } from "../../../types/json";
+import HighlightMatch from "../../HighlightMatch";
 
 const listStyles = css`
   font-family: monospace;
@@ -22,12 +23,14 @@ interface EntityListProps {
   data: Record<string, JSONObject>;
   selectedCacheId: string;
   setCacheId: (cacheId: string) => void;
+  searchTerm: string;
 }
 
 export function EntityList({
   data,
   selectedCacheId,
   setCacheId,
+  searchTerm,
 }: EntityListProps) {
   const theme = useTheme();
   const ids = getRootCacheIds(data);
@@ -45,7 +48,11 @@ export function EntityList({
             onClick={() => setCacheId(cacheId)}
             selected={cacheId === selectedCacheId}
           >
-            {cacheId}
+            {searchTerm ? (
+              <HighlightMatch searchTerm={searchTerm} value={cacheId} />
+            ) : (
+              cacheId
+            )}
           </ListItem>
         );
       })}

--- a/src/application/components/Cache/sidebar/Search.tsx
+++ b/src/application/components/Cache/sidebar/Search.tsx
@@ -1,13 +1,10 @@
-import { ChangeEvent } from "react";
 import { IconSearch } from "@apollo/space-kit/icons/IconSearch";
 import { TextField } from "@apollo/space-kit/TextField";
 import { colors } from "@apollo/space-kit/colors";
 import { css } from "@emotion/react";
 import { rem } from "polished";
 
-import { objectFilter } from "../common/utils";
 import { useTheme, Theme } from "../../../theme";
-import { JSONObject } from "../../../types/json";
 
 const searchIconStyles = (theme: Theme) => ({
   height: 16,
@@ -40,28 +37,12 @@ const textFieldStyles = css`
 `;
 
 interface SearchProps {
-  data: Record<string, JSONObject>;
-  setSearchResults: (results: Record<string, JSONObject>) => void;
+  value: string;
+  onChange: (value: string) => void;
 }
 
-export const Search = ({ data, setSearchResults }: SearchProps) => {
+export const Search = ({ onChange, value }: SearchProps) => {
   const theme = useTheme();
-
-  function performSearch(event: ChangeEvent<HTMLInputElement>) {
-    const keywords = event.target.value;
-    if (keywords.trim() === "") {
-      setSearchResults({});
-    }
-
-    if (keywords.length >= 2) {
-      const searchResults: Record<string, JSONObject> = {};
-      Object.keys(data).forEach((dataId) => {
-        const results = objectFilter(data[dataId], keywords);
-        if (results) searchResults[dataId] = results;
-      });
-      setSearchResults(searchResults);
-    }
-  }
 
   return (
     <TextField
@@ -69,8 +50,9 @@ export const Search = ({ data, setSearchResults }: SearchProps) => {
       icon={<IconSearch style={searchIconStyles(theme)} />}
       className="search-input"
       placeholder="Search queries"
-      onChange={performSearch}
+      onChange={(e) => onChange(e.target.value)}
       size="small"
+      value={value}
     />
   );
 };

--- a/src/application/components/Cache/sidebar/Search.tsx
+++ b/src/application/components/Cache/sidebar/Search.tsx
@@ -53,7 +53,7 @@ export const Search = ({ data, setSearchResults }: SearchProps) => {
       setSearchResults({});
     }
 
-    if (keywords.length >= 3) {
+    if (keywords.length >= 2) {
       const searchResults: Record<string, JSONObject> = {};
       Object.keys(data).forEach((dataId) => {
         const results = objectFilter(data[dataId], keywords);

--- a/src/application/components/HighlightMatch.tsx
+++ b/src/application/components/HighlightMatch.tsx
@@ -15,7 +15,7 @@ const HighlightMatch = ({ searchTerm, value }: HighlightMatchProps) => {
   }
 
   return (
-    <>
+    <span>
       {value.slice(0, match.index)}
       <span
         css={css`
@@ -26,7 +26,7 @@ const HighlightMatch = ({ searchTerm, value }: HighlightMatchProps) => {
         {match[0]}
       </span>
       {value.slice(match.index + searchTerm.length)}
-    </>
+    </span>
   );
 };
 

--- a/src/application/components/HighlightMatch.tsx
+++ b/src/application/components/HighlightMatch.tsx
@@ -1,0 +1,33 @@
+import { css } from "@emotion/react";
+import { colors } from "@apollo/space-kit/colors";
+
+interface HighlightMatchProps {
+  searchTerm: string;
+  value: string;
+}
+
+const HighlightMatch = ({ searchTerm, value }: HighlightMatchProps) => {
+  const regex = new RegExp(searchTerm, "i");
+  const match = regex.exec(value);
+
+  if (!match) {
+    return <>{value}</>;
+  }
+
+  return (
+    <>
+      {value.slice(0, match.index)}
+      <span
+        css={css`
+          color: ${colors.grey.darker};
+          background: ${colors.yellow.base};
+        `}
+      >
+        {match[0]}
+      </span>
+      {value.slice(match.index + searchTerm.length)}
+    </>
+  );
+};
+
+export default HighlightMatch;


### PR DESCRIPTION
Searching the cache in the devtools has always felt a little bit broken. At present, it doesn't do any filtering of the list, so matches against the search string are very difficult to find if the list of cache keys is large (see example in [this discussion](https://github.com/apollographql/apollo-client-devtools/discussions/867)). Furthermore, it would match against values in the cache entry itself, but this was difficult to find since it required you to activate the cache entry to see it.

This PR improves the search functionality by matching only against cache keys and actively filtering that list as the user types. The matched string in the cache key is also now highlighted so its obvious how the record is filtered. This should improve cases where you might have an ID and want to quickly see what what a record with that ID contains by pasting that ID into the search field.

**Before**
![search-old](https://github.com/apollographql/apollo-client-devtools/assets/565661/a6090fd4-eb80-4687-92f7-40c70bcae757)


**After**
![search-new](https://github.com/apollographql/apollo-client-devtools/assets/565661/3ff84f56-1334-4f2d-9d6b-57bc833ae8bd)

