### PR TITLE
update secops orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  secops: apollo/circleci-secops-orb@2.0.0
+  secops: apollo/circleci-secops-orb@2.0.1
 
 jobs:
   lint:


### PR DESCRIPTION
## Motivation / Implements
This PR updates the version of the SecOps orb used in this repo. Version 2.0.0 of the orb included an issue on the gitleaks job that prevented the job from running on PRs created from forks. The issue was caused by a default configuration in CircleCI which prevents providing secrets provided through CircleCI contexts to PRs created from forks. This default configuration is probably the correct one, so we needed up update the SecOps orb to properly operated on PRs from forks.

## Changed
- Update circleci-secops-orb to version 2.0.1