### PR TITLE
change script injection approach to use a temporary `<script` tag

### DIFF
--- a/.changeset/yellow-wolves-switch.md
+++ b/.changeset/yellow-wolves-switch.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": minor
+---
+
+Change the tab script injection mechanism for better compatibility with websites that might see hydration mismatches with the old injection mechanism.

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -2,25 +2,33 @@
 import "./tabRelay";
 import browser from "webextension-polyfill";
 
-/* 
-  Content scripts are unable to modify the window object directly. 
-  A common workaround for this issue is to inject an inlined function
-  into the inspected tab.
-*/
-if (typeof document === "object" && document instanceof HTMLDocument) {
-  const script = document.createElement("script");
-  script.setAttribute("type", "module");
-  script.setAttribute("src", browser.runtime.getURL("hook.js"));
-  document.addEventListener("DOMContentLoaded", () => {
-    const importMap = document.querySelector('script[type="importmap"]');
-    if (importMap != null) {
-      importMap.parentNode?.insertBefore(script, importMap.nextSibling);
-    } else {
-      const head =
-        document.head ||
-        document.getElementsByTagName("head")[0] ||
-        document.documentElement;
-      head.insertBefore(script, head.lastChild);
-    }
+injectScriptSync(browser.runtime.getURL("hook.js"));
+
+// In this content script we have access to DOM, but don't have access to the webpage's window,
+// so we inject this inline script tag into the webpage (allowed in Manifest V2).
+// In Manifest V3, we'll have to switch this approach for Chrome-based browsers.
+// This function is based on
+// https://github.com/facebook/react/blob/18a9dd1c60fdb711982f32ce5d91acfe8f158fe1/packages/react-devtools-extensions/src/contentScripts/prepareInjection.js
+// which is released under a MIT license (Copyright (c) Meta Platforms, Inc. and affiliates.) that can be found here:
+// https://github.com/facebook/react/blob/18a9dd1c60fdb711982f32ce5d91acfe8f158fe1/LICENSE
+function injectScriptSync(src: string) {
+  let code = "";
+  const request = new XMLHttpRequest();
+  request.addEventListener("load", function () {
+    code = this.responseText;
   });
+  request.open("GET", src, false);
+  request.send();
+
+  const script = document.createElement("script");
+  script.textContent = code;
+
+  // This script runs before the <head> element is created,
+  // so we add the script to <html> instead.
+  if (typeof document === "object" && document instanceof HTMLDocument) {
+    document.documentElement.appendChild(script);
+    if (script.parentNode) {
+      script.parentNode?.removeChild(script);
+    }
+  }
 }


### PR DESCRIPTION
This would potentially fix #1162, #937 and #839 

It's just a temporary fix though, as for Chrome we'll have to switch to manifest v3 soon, but it will be less of a problem there since that allows to inject content scripts into `ExecutionWorld.MAIN`.