### PR TITLE
Fix font size in code blocks

### DIFF
--- a/.changeset/tiny-scissors-turn.md
+++ b/.changeset/tiny-scissors-turn.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix font size of code blocks to match new Apollo design system.

--- a/src/application/components/CodeBlock.tsx
+++ b/src/application/components/CodeBlock.tsx
@@ -141,7 +141,7 @@ export const CodeBlock = ({
     <div
       className={clsx(
         className,
-        "flex gap-1 items-start bg-secondary dark:bg-secondary-dark p-4 rounded-lg relative border border-primary dark:border-primary-dark overflow-auto"
+        "flex gap-1 items-start bg-secondary dark:bg-secondary-dark p-4 rounded-lg relative border border-primary dark:border-primary-dark overflow-auto text-sm"
       )}
     >
       <Highlight language={language} theme={activeTheme} code={code}>


### PR DESCRIPTION
The font size for code blocks does not currently match the design. Code blocks should be set at 0.875rem (14px) but instead scaled with the text around it. This PR adjusts the font size to match the code block design.

### Before
<img width="1512" alt="Screenshot 2024-01-25 at 9 50 40 PM" src="https://github.com/apollographql/apollo-client-devtools/assets/565661/d518a61f-01ee-4d20-8861-55c766ee7c0c">

### After
<img width="1512" alt="Screenshot 2024-01-25 at 9 50 28 PM" src="https://github.com/apollographql/apollo-client-devtools/assets/565661/419d317f-cf1b-4bd7-a525-482a8cb7f603">



