### PR TITLE
Fix issue sending cache data to devtools when the cache contains a `URL` instance

### DIFF
--- a/.changeset/long-balloons-attack.md
+++ b/.changeset/long-balloons-attack.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix an issue when sending cache data from the browser to the extension. This was particularly problematic when the cache contained `URL` instances which are not cloneable via the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)

--- a/src/application/components/Cache/__tests__/Cache.test.tsx
+++ b/src/application/components/Cache/__tests__/Cache.test.tsx
@@ -78,7 +78,7 @@ describe("Cache component tests", () => {
       writeData({
         queries: [],
         mutations: [],
-        cache: CACHE_DATA,
+        cache: JSON.stringify(CACHE_DATA),
       });
     });
 
@@ -126,7 +126,7 @@ describe("Cache component tests", () => {
       writeData({
         queries: [],
         mutations: [],
-        cache: CACHE_DATA,
+        cache: JSON.stringify(CACHE_DATA),
       });
     });
 

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -152,7 +152,7 @@ export const writeData = ({
 }: {
   queries: QueryInfo[];
   mutations: QueryInfo[];
-  cache: Record<string, unknown>;
+  cache: string;
 }) => {
   const filteredQueries = queries.map(getQueryData).filter(Boolean);
 
@@ -179,7 +179,7 @@ export const writeData = ({
       },
     },
   });
-  cacheVar(JSON.stringify(cache));
+  cacheVar(cache);
 };
 
 export const AppProvider = () => {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -1,6 +1,5 @@
 import { createMachine } from "./stateMachine";
 import { QueryInfo } from "../extension/tab/helpers";
-import { JSONObject } from "./types/json";
 
 export const devtoolsMachine = createMachine({
   initial: "initialized",
@@ -16,7 +15,7 @@ export const devtoolsMachine = createMachine({
     clientContext: {
       queries: [] as QueryInfo[],
       mutations: [] as QueryInfo[],
-      cache: {} as JSONObject,
+      cache: "",
     },
   },
   states: {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -15,7 +15,7 @@ export const devtoolsMachine = createMachine({
     clientContext: {
       queries: [] as QueryInfo[],
       mutations: [] as QueryInfo[],
-      cache: "",
+      cache: "{}",
     },
   },
   states: {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -107,7 +107,8 @@ function initializeHook() {
         // references to `URL` instances which are not cloneable via
         // `structuredClone` (which `window.postMessage` uses to send messages).
         // `JSON.stringify` does however serialize `URL`s into strings properly,
-        // so this ensures that the cache data will be sent properly.
+        // so this should ensure that the cache data will be sent without
+        // errors.
         //
         // https://github.com/apollographql/apollo-client-devtools/issues/1258
         cache: JSON.stringify(hook.getCache()),

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -102,7 +102,7 @@ function initializeHook() {
       payload: {
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
-        cache: hook.getCache(),
+        cache: JSON.stringify(hook.getCache()),
       },
     });
   }

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -102,6 +102,14 @@ function initializeHook() {
       payload: {
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
+
+        // We need to JSON stringify the cache here in case the cache contains
+        // references to `URL` instances which are not cloneable via
+        // `structuredClone` (which `window.postMessage` uses to send messages).
+        // `JSON.stringify` does however serialize `URL`s into strings properly,
+        // so this ensures that the cache data will be sent properly.
+        //
+        // https://github.com/apollographql/apollo-client-devtools/issues/1258
         cache: JSON.stringify(hook.getCache()),
       },
     });


### PR DESCRIPTION
Fixes #1258

https://github.com/apollographql/apollo-client-devtools/pull/1245 removed the `JSON.stringify` call before sending the client data from the content script to the devtools script. While this mostly works well, there are some cases where this blows up, such as when the cache contains a `URL` instance. `URL` is a JSON serializable value, but unfortunately does not work with [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). This PR reverts this change to serialize the cache before sending it to the devtools script.