### PR TITLE
Fully fix issue sending data from client to devtools

### DIFF
--- a/.changeset/pretty-cars-jump.md
+++ b/.changeset/pretty-cars-jump.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Revert change that removed JSON stringify on the entire set of client data. This is a followup to [#1259](https://github.com/apollographql/apollo-client-devtools/pull/1259) which only partially fixed the issue.

--- a/src/application/components/Cache/__tests__/Cache.test.tsx
+++ b/src/application/components/Cache/__tests__/Cache.test.tsx
@@ -78,7 +78,7 @@ describe("Cache component tests", () => {
       writeData({
         queries: [],
         mutations: [],
-        cache: JSON.stringify(CACHE_DATA),
+        cache: CACHE_DATA,
       });
     });
 
@@ -126,7 +126,7 @@ describe("Cache component tests", () => {
       writeData({
         queries: [],
         mutations: [],
-        cache: JSON.stringify(CACHE_DATA),
+        cache: CACHE_DATA,
       });
     });
 

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -24,6 +24,7 @@ import type {
   WatchedQuery,
 } from "./types/gql";
 import type { QueryInfo } from "../extension/tab/helpers";
+import type { JSONObject } from "./types/json";
 
 const cache = new InMemoryCache({
   fragments: fragmentRegistry,
@@ -152,7 +153,7 @@ export const writeData = ({
 }: {
   queries: QueryInfo[];
   mutations: QueryInfo[];
-  cache: string;
+  cache: JSONObject;
 }) => {
   const filteredQueries = queries.map(getQueryData).filter(Boolean);
 
@@ -179,7 +180,7 @@ export const writeData = ({
       },
     },
   });
-  cacheVar(cache);
+  cacheVar(JSON.stringify(cache));
 };
 
 export const AppProvider = () => {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -1,5 +1,4 @@
 import { createMachine } from "./stateMachine";
-import type { QueryInfo } from "../extension/tab/helpers";
 
 export const devtoolsMachine = createMachine({
   initial: "initialized",
@@ -12,11 +11,12 @@ export const devtoolsMachine = createMachine({
       | { type: "retry" },
   },
   initialContext: {
-    clientContext: {
-      queries: [] as QueryInfo[],
-      mutations: [] as QueryInfo[],
-      cache: "{}",
-    },
+    // This value needs to be JSON stringified so that it can be sent through
+    // postMessage without error. Irregular cache data (such as `URL` instances
+    // stored in the cache) are not cloneable via the `structuredClone`
+    // algorithm.
+    // https://github.com/apollographql/apollo-client-devtools/issues/1258
+    clientContext: JSON.stringify({ queries: [], mutations: [], cache: {} }),
   },
   states: {
     initialized: {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -1,5 +1,6 @@
 import { createMachine } from "./stateMachine";
 import type { QueryInfo } from "../extension/tab/helpers";
+import type { JSONObject } from "./types/json";
 
 export const devtoolsMachine = createMachine({
   initial: "initialized",
@@ -15,7 +16,7 @@ export const devtoolsMachine = createMachine({
     clientContext: {
       queries: [] as QueryInfo[],
       mutations: [] as QueryInfo[],
-      cache: "{}",
+      cache: {} as JSONObject,
     },
   },
   states: {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -1,4 +1,5 @@
 import { createMachine } from "./stateMachine";
+import type { QueryInfo } from "../extension/tab/helpers";
 
 export const devtoolsMachine = createMachine({
   initial: "initialized",
@@ -11,12 +12,11 @@ export const devtoolsMachine = createMachine({
       | { type: "retry" },
   },
   initialContext: {
-    // This value needs to be JSON stringified so that it can be sent through
-    // postMessage without error. Irregular cache data (such as `URL` instances
-    // stored in the cache) are not cloneable via the `structuredClone`
-    // algorithm.
-    // https://github.com/apollographql/apollo-client-devtools/issues/1258
-    clientContext: JSON.stringify({ queries: [], mutations: [], cache: {} }),
+    clientContext: {
+      queries: [] as QueryInfo[],
+      mutations: [] as QueryInfo[],
+      cache: "{}",
+    },
   },
   states: {
     initialized: {

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -141,15 +141,7 @@ async function createDevtoolsPanel() {
       unsubscribers.add(startRequestInterval());
     }
 
-    removeUpdateListener = clientPort.on("update", (message) => {
-      const { queries, mutations, cache } = message.payload;
-
-      panelWindow.send({
-        type: "update",
-        payload: { queries, mutations, cache },
-      });
-    });
-
+    removeUpdateListener = clientPort.forward("update", panelWindow);
     removeExplorerForward = clientPort.forward("explorerResponse", panelWindow);
     removeExplorerListener = panelWindow.forward("explorerRequest", clientPort);
     removeSubscriptionTerminationListener = panelWindow.forward(

--- a/src/extension/devtools/panel.ts
+++ b/src/extension/devtools/panel.ts
@@ -2,12 +2,22 @@ import { initDevTools, writeData, client } from "../../application";
 import "./panel.css";
 import { devtoolsState } from "../../application/App";
 import { getPanelActor } from "./panelActor";
+import type { QueryInfo } from "../tab/helpers";
+import type { JSONObject } from "../../application/types/json";
 
 const panelWindow = getPanelActor(window);
 
+function parseClientData(payload: string) {
+  return JSON.parse(payload) as {
+    queries: QueryInfo[];
+    mutations: QueryInfo[];
+    cache: JSONObject;
+  };
+}
+
 panelWindow.on("initializePanel", (message) => {
   devtoolsState(message.state);
-  writeData(message.payload);
+  writeData(parseClientData(message.payload));
 
   initDevTools();
 });
@@ -21,5 +31,5 @@ panelWindow.on("devtoolsStateChanged", (message) => {
 });
 
 panelWindow.on("update", (message) => {
-  writeData(message.payload);
+  writeData(parseClientData(message.payload));
 });

--- a/src/extension/devtools/panel.ts
+++ b/src/extension/devtools/panel.ts
@@ -2,22 +2,12 @@ import { initDevTools, writeData, client } from "../../application";
 import "./panel.css";
 import { devtoolsState } from "../../application/App";
 import { getPanelActor } from "./panelActor";
-import type { QueryInfo } from "../tab/helpers";
-import type { JSONObject } from "../../application/types/json";
 
 const panelWindow = getPanelActor(window);
 
-function parseClientData(payload: string) {
-  return JSON.parse(payload) as {
-    queries: QueryInfo[];
-    mutations: QueryInfo[];
-    cache: JSONObject;
-  };
-}
-
 panelWindow.on("initializePanel", (message) => {
   devtoolsState(message.state);
-  writeData(parseClientData(message.payload));
+  writeData(message.payload);
 
   initDevTools();
 });
@@ -31,5 +21,5 @@ panelWindow.on("devtoolsStateChanged", (message) => {
 });
 
 panelWindow.on("update", (message) => {
-  writeData(parseClientData(message.payload));
+  writeData(message.payload);
 });

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -95,11 +95,11 @@ function initializeHook() {
     tab.send({
       type: eventName,
       // We need to JSON stringify the data here in case the cache contains
-      // references to `URL` instances which are not cloneable via
-      // `structuredClone` (which `window.postMessage` uses to send messages).
-      // `JSON.stringify` does however serialize `URL`s into strings properly,
-      // so this should ensure that the cache data will be sent without
-      // errors.
+      // references to irregular data such as `URL` instances which are not
+      // cloneable via `structuredClone` (which `window.postMessage` uses to
+      // send messages). `JSON.stringify` does however serialize `URL`s into
+      // strings properly, so this should ensure that the cache data will be
+      // sent without errors.
       //
       // https://github.com/apollographql/apollo-client-devtools/issues/1258
       payload: JSON.parse(

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -94,19 +94,20 @@ function initializeHook() {
   function sendHookDataToDevTools(eventName: "update" | "connectToDevtools") {
     tab.send({
       type: eventName,
-      // We need to JSON stringify the payload here in case the cache contains
-      // references to `URL` instances (or other data) that is not cloneable via
-      // `structuredClone`, which `window.postMessage` uses to send messages.
-      // `JSON.stringify` does however serialize `URL`s into strings properly,
-      // so this should ensure that the cache data will be sent without
-      // errors.
-      //
-      // https://github.com/apollographql/apollo-client-devtools/issues/1258
-      payload: JSON.stringify({
+      payload: {
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
-        cache: hook.getCache(),
-      }),
+
+        // We need to JSON stringify the cache here in case the cache contains
+        // references to `URL` instances which are not cloneable via
+        // `structuredClone` (which `window.postMessage` uses to send messages).
+        // `JSON.stringify` does however serialize `URL`s into strings properly,
+        // so this should ensure that the cache data will be sent without
+        // errors.
+        //
+        // https://github.com/apollographql/apollo-client-devtools/issues/1258
+        cache: JSON.stringify(hook.getCache()),
+      },
     });
   }
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -94,20 +94,21 @@ function initializeHook() {
   function sendHookDataToDevTools(eventName: "update" | "connectToDevtools") {
     tab.send({
       type: eventName,
-      payload: {
-        queries: hook.getQueries(),
-        mutations: hook.getMutations(),
-
-        // We need to JSON stringify the cache here in case the cache contains
-        // references to `URL` instances which are not cloneable via
-        // `structuredClone` (which `window.postMessage` uses to send messages).
-        // `JSON.stringify` does however serialize `URL`s into strings properly,
-        // so this should ensure that the cache data will be sent without
-        // errors.
-        //
-        // https://github.com/apollographql/apollo-client-devtools/issues/1258
-        cache: JSON.stringify(hook.getCache()),
-      },
+      // We need to JSON stringify the data here in case the cache contains
+      // references to `URL` instances which are not cloneable via
+      // `structuredClone` (which `window.postMessage` uses to send messages).
+      // `JSON.stringify` does however serialize `URL`s into strings properly,
+      // so this should ensure that the cache data will be sent without
+      // errors.
+      //
+      // https://github.com/apollographql/apollo-client-devtools/issues/1258
+      payload: JSON.parse(
+        JSON.stringify({
+          queries: hook.getQueries(),
+          mutations: hook.getMutations(),
+          cache: hook.getCache(),
+        })
+      ) as { queries: QueryInfo[]; mutations: QueryInfo[]; cache: JSONObject },
     });
   }
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -94,20 +94,19 @@ function initializeHook() {
   function sendHookDataToDevTools(eventName: "update" | "connectToDevtools") {
     tab.send({
       type: eventName,
-      payload: {
+      // We need to JSON stringify the payload here in case the cache contains
+      // references to `URL` instances (or other data) that is not cloneable via
+      // `structuredClone`, which `window.postMessage` uses to send messages.
+      // `JSON.stringify` does however serialize `URL`s into strings properly,
+      // so this should ensure that the cache data will be sent without
+      // errors.
+      //
+      // https://github.com/apollographql/apollo-client-devtools/issues/1258
+      payload: JSON.stringify({
         queries: hook.getQueries(),
         mutations: hook.getMutations(),
-
-        // We need to JSON stringify the cache here in case the cache contains
-        // references to `URL` instances which are not cloneable via
-        // `structuredClone` (which `window.postMessage` uses to send messages).
-        // `JSON.stringify` does however serialize `URL`s into strings properly,
-        // so this should ensure that the cache data will be sent without
-        // errors.
-        //
-        // https://github.com/apollographql/apollo-client-devtools/issues/1258
-        cache: JSON.stringify(hook.getCache()),
-      },
+        cache: hook.getCache(),
+      }),
     });
   }
 


### PR DESCRIPTION
Fully reverts changes from https://github.com/apollographql/apollo-client-devtools/pull/1245 that removed `JSON.stringify` from the entire client payload. Irregular cache values caused some issues when serializing on all fields.