### PR TITLE
Add `onLeave` callback for state machine transitions

### DIFF
--- a/src/application/__tests__/stateMachine.test.ts
+++ b/src/application/__tests__/stateMachine.test.ts
@@ -203,7 +203,7 @@ test("can listen to transitions from a specific state", () => {
 
   const onListener = jest.fn();
   const offListener = jest.fn();
-  machine.onLeave("on", onListener);
+  const unsubscribe = machine.onLeave("on", onListener);
   machine.onLeave("off", offListener);
 
   machine.send({ type: "turnOn" });
@@ -213,6 +213,10 @@ test("can listen to transitions from a specific state", () => {
   machine.send({ type: "turnOff" });
   expect(onListener).toHaveBeenCalledTimes(1);
   expect(offListener).toHaveBeenCalledTimes(1);
+
+  unsubscribe();
+  machine.send({ type: "turnOn" });
+  expect(onListener).toHaveBeenCalledTimes(1);
 });
 
 test("runs leave listeners before transition listeners", () => {

--- a/src/application/__tests__/stateMachine.test.ts
+++ b/src/application/__tests__/stateMachine.test.ts
@@ -180,3 +180,37 @@ test("can listen to transitions to a specific state", () => {
   expect(onListener).toHaveBeenCalledTimes(1);
   expect(offListener).toHaveBeenCalledTimes(1);
 });
+
+test("can listen to transitions from a specific state", () => {
+  const machine = createMachine({
+    initial: "off",
+    types: {} as {
+      events: { type: "turnOn" } | { type: "turnOff" };
+    },
+    states: {
+      off: {
+        events: {
+          turnOn: "on",
+        },
+      },
+      on: {
+        events: {
+          turnOff: "off",
+        },
+      },
+    },
+  });
+
+  const onListener = jest.fn();
+  const offListener = jest.fn();
+  machine.onLeave("on", onListener);
+  machine.onLeave("off", offListener);
+
+  machine.send({ type: "turnOn" });
+  expect(onListener).toHaveBeenCalledTimes(0);
+  expect(offListener).toHaveBeenCalledTimes(1);
+
+  machine.send({ type: "turnOff" });
+  expect(onListener).toHaveBeenCalledTimes(1);
+  expect(offListener).toHaveBeenCalledTimes(1);
+});

--- a/src/application/__tests__/stateMachine.test.ts
+++ b/src/application/__tests__/stateMachine.test.ts
@@ -214,3 +214,32 @@ test("can listen to transitions from a specific state", () => {
   expect(onListener).toHaveBeenCalledTimes(1);
   expect(offListener).toHaveBeenCalledTimes(1);
 });
+
+test("runs leave listeners before transition listeners", () => {
+  const machine = createMachine({
+    initial: "off",
+    types: {} as {
+      events: { type: "turnOn" } | { type: "turnOff" };
+    },
+    states: {
+      off: {
+        events: {
+          turnOn: "on",
+        },
+      },
+      on: {
+        events: {
+          turnOff: "off",
+        },
+      },
+    },
+  });
+
+  const listener = jest.fn();
+  machine.onLeave("off", () => listener("onLeave"));
+  machine.onTransition("on", () => listener("onTransition"));
+
+  machine.send({ type: "turnOn" });
+  expect(listener).toHaveBeenNthCalledWith(1, "onLeave");
+  expect(listener).toHaveBeenNthCalledWith(2, "onTransition");
+});

--- a/src/application/__tests__/stateMachine.test.ts
+++ b/src/application/__tests__/stateMachine.test.ts
@@ -1,0 +1,182 @@
+import { createMachine } from "../stateMachine";
+
+test("getState returns initial state", () => {
+  const machine = createMachine({
+    initial: "idle",
+    initialContext: {},
+    types: {} as { events: { type: "ignore" } },
+    states: {
+      idle: {},
+    },
+  });
+
+  expect(machine.getState()).toEqual({ value: "idle", context: {} });
+});
+
+test("can transition to another state", () => {
+  const machine = createMachine({
+    initial: "off",
+    initialContext: {},
+    types: {} as {
+      events: { type: "on" } | { type: "off" };
+    },
+    states: {
+      off: {
+        events: {
+          on: "on",
+        },
+      },
+      on: {
+        events: { off: "off" },
+      },
+    },
+  });
+
+  machine.send({ type: "on" });
+
+  expect(machine.getState()).toEqual({ value: "on", context: {} });
+});
+
+test("does not transition and warns when sending event that current state does not handle", () => {
+  const originalEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+
+  const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  const machine = createMachine({
+    initial: "pending",
+    initialContext: {},
+    types: {} as {
+      events: { type: "resolve" } | { type: "reject" };
+    },
+    states: {
+      pending: {
+        events: {
+          resolve: "fulfilled",
+          reject: "rejected",
+        },
+      },
+      fulfilled: {},
+      rejected: {},
+    },
+  });
+
+  machine.send({ type: "resolve" });
+  machine.send({ type: "reject" });
+
+  expect(machine.getState()).toEqual({ value: "fulfilled", context: {} });
+
+  expect(consoleSpy).toHaveBeenCalledTimes(1);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    "Transition from state 'fulfilled' for event 'reject' not found."
+  );
+
+  consoleSpy.mockRestore();
+  process.env.NODE_ENV = originalEnv;
+});
+
+test("can set context on machine while sending event", () => {
+  const machine = createMachine({
+    initial: "pending",
+    initialContext: {
+      value: "initial",
+    },
+    types: {} as {
+      events: { type: "resolve" } | { type: "reject" };
+    },
+    states: {
+      pending: {
+        events: {
+          resolve: "fulfilled",
+          reject: "rejected",
+        },
+      },
+      fulfilled: {},
+      rejected: {},
+    },
+  });
+
+  expect(machine.getState()).toEqual({
+    value: "pending",
+    context: { value: "initial" },
+  });
+
+  machine.send({ type: "resolve", context: { value: "resolved" } });
+
+  expect(machine.getState()).toEqual({
+    value: "fulfilled",
+    context: { value: "resolved" },
+  });
+});
+
+test("can subscribe to state changes", () => {
+  const machine = createMachine({
+    initial: "off",
+    initialContext: { count: 0 },
+    types: {} as {
+      events: { type: "turnOn" } | { type: "turnOff" };
+    },
+    states: {
+      off: {
+        events: {
+          turnOn: "on",
+        },
+      },
+      on: {
+        events: {
+          turnOff: "off",
+        },
+      },
+    },
+  });
+
+  const listener = jest.fn();
+  const unsubscribe = machine.subscribe(listener);
+
+  machine.send({ type: "turnOn", context: { count: 1 } });
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith({
+    state: { value: "on", context: { count: 1 } },
+    event: { type: "turnOn", context: { count: 1 } },
+  });
+
+  unsubscribe();
+
+  machine.send({ type: "turnOff", context: { count: 2 } });
+
+  expect(listener).toHaveBeenCalledTimes(1);
+});
+
+test("can listen to transitions to a specific state", () => {
+  const machine = createMachine({
+    initial: "off",
+    types: {} as {
+      events: { type: "turnOn" } | { type: "turnOff" };
+    },
+    states: {
+      off: {
+        events: {
+          turnOn: "on",
+        },
+      },
+      on: {
+        events: {
+          turnOff: "off",
+        },
+      },
+    },
+  });
+
+  const onListener = jest.fn();
+  const offListener = jest.fn();
+  machine.onTransition("on", onListener);
+  machine.onTransition("off", offListener);
+
+  machine.send({ type: "turnOn" });
+  expect(onListener).toHaveBeenCalledTimes(1);
+  expect(offListener).toHaveBeenCalledTimes(0);
+
+  machine.send({ type: "turnOff" });
+  expect(onListener).toHaveBeenCalledTimes(1);
+  expect(offListener).toHaveBeenCalledTimes(1);
+});

--- a/src/application/stateMachine.ts
+++ b/src/application/stateMachine.ts
@@ -12,7 +12,7 @@ interface Machine<
     state: State,
     listener: () => void
   ) => () => void | (() => void);
-  onLeave: (state: State, listener: () => void) => void;
+  onLeave: (state: State, listener: () => void) => () => void;
   matches: (state: State) => boolean;
 }
 

--- a/src/application/stateMachine.ts
+++ b/src/application/stateMachine.ts
@@ -77,7 +77,7 @@ export function createMachine<
   machine: MachineConfig<State, EventName, Context>
 ): Machine<State, EventName, Context> {
   const listeners = new Set<Listener<State, EventName, Context>>();
-  const stateListeners = new Map<State, Set<() => void>>();
+  const transitionListeners = new Map<State, Set<() => void>>();
   const leaveListeners = new Map<State, Set<() => void>>();
 
   const current = {
@@ -114,7 +114,7 @@ export function createMachine<
     listeners.forEach((listener) =>
       listener({ state: current, event: sourceEvent })
     );
-    stateListeners.get(state)?.forEach((listener) => listener());
+    transitionListeners.get(state)?.forEach((listener) => listener());
   }
 
   function getState() {
@@ -130,11 +130,11 @@ export function createMachine<
   }
 
   function onTransition(state: State, listener: () => void) {
-    if (!stateListeners.has(state)) {
-      stateListeners.set(state, new Set());
+    if (!transitionListeners.has(state)) {
+      transitionListeners.set(state, new Set());
     }
 
-    const listeners = stateListeners.get(state)!;
+    const listeners = transitionListeners.get(state)!;
     listeners.add(listener);
 
     return () => listeners?.delete(listener);
@@ -145,7 +145,7 @@ export function createMachine<
   }
 
   function onLeave(state: State, listener: () => void) {
-    if (!stateListeners.has(state)) {
+    if (!transitionListeners.has(state)) {
       leaveListeners.set(state, new Set());
     }
 


### PR DESCRIPTION
Adds the ability to run a callback when leaving a particular state in a state machine. This can be done either by calling `machine.onLeave('state', callback)`, or by returning a function from `machine.onTransition(...)` that will be called when leaving the state.

The functionality in the machine is done, but I'd like to do a couple small refactorings after https://github.com/apollographql/apollo-client-devtools/pull/1279 is merged in.