### PR TITLE
Handle client termination and recreation

### DIFF
--- a/.changeset/fresh-donkeys-clean.md
+++ b/.changeset/fresh-donkeys-clean.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix issue where terminating the client by calling `.stop` would not disconnect it from devtools making it difficult to track newly created clients.

--- a/development/client/src/App.js
+++ b/development/client/src/App.js
@@ -49,7 +49,15 @@ function Layout({ onChangeClient }) {
           <Link to="/favorites">Favorites</Link>
           <Link to="/lookup">Lookup</Link>
         </nav>
-        <div>
+        <div style={{ display: "flex", gap: "1rem" }}>
+          <button
+            onClick={() => {
+              client.stop();
+              onChangeClient(createClient());
+            }}
+          >
+            Recreate client
+          </button>
           <button
             onClick={() => {
               client.stop();

--- a/development/client/src/App.js
+++ b/development/client/src/App.js
@@ -1,6 +1,12 @@
-import React from "react";
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
-import { useQuery } from "@apollo/client";
+import React, { useState } from "react";
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import {
+  ApolloClient,
+  ApolloProvider,
+  InMemoryCache,
+  makeReference,
+  useQuery,
+} from "@apollo/client";
 import ColorSchemeGenerator from "./ColorSchemeGenerator";
 import Favorites from "./Favorites";
 import ColorLookup from "./ColorLookup";
@@ -8,30 +14,88 @@ import { GET_SAVED_COLORS } from "./queries";
 import "./App.css";
 
 function App() {
-  useQuery(GET_SAVED_COLORS);
+  const [client, setClient] = useState(() => createClient());
+
+  if (!client) {
+    return (
+      <div style={{ textAlign: "center" }}>
+        <h1>Client was terminated</h1>
+        <button onClick={() => setClient(createClient())}>
+          Recreate client
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <Router>
-      <div className="App">
-        <header>
-          <Link to="/">
-            <h1>Colors</h1>
-          </Link>
-          <nav>
-            <Link to="/favorites">Favorites</Link>
-            <Link to="/lookup">Lookup</Link>
-          </nav>
-        </header>
-        <main>
-          <Routes>
-            <Route path="/favorites" element={<Favorites />} />
-            <Route path="/lookup" element={<ColorLookup />} />
-            <Route path="/" element={<ColorSchemeGenerator />} />
-          </Routes>
-        </main>
-      </div>
-    </Router>
+    <ApolloProvider client={client}>
+      <BrowserRouter>
+        <Layout onChangeClient={(client) => setClient(client)} />
+      </BrowserRouter>
+    </ApolloProvider>
   );
+}
+
+function Layout({ onChangeClient }) {
+  const { client } = useQuery(GET_SAVED_COLORS);
+
+  return (
+    <div className="App">
+      <header style={{ display: "flex" }}>
+        <Link to="/">
+          <h1>Colors</h1>
+        </Link>
+        <nav style={{ flex: 1 }}>
+          <Link to="/favorites">Favorites</Link>
+          <Link to="/lookup">Lookup</Link>
+        </nav>
+        <div>
+          <button
+            onClick={() => {
+              client.stop();
+              onChangeClient(null);
+            }}
+          >
+            Terminate client
+          </button>
+        </div>
+      </header>
+      <main>
+        <Routes>
+          <Route path="/favorites" element={<Favorites />} />
+          <Route path="/lookup" element={<ColorLookup />} />
+          <Route path="/" element={<ColorSchemeGenerator />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+function createClient() {
+  return new ApolloClient({
+    cache: new InMemoryCache({
+      typePolicies: {
+        Color: {
+          keyFields: ["hex"],
+          fields: {
+            saved: {
+              read(_, { readField }) {
+                const hex = readField("hex");
+                const favoritedColors = readField(
+                  "favoritedColors",
+                  makeReference("ROOT_QUERY")
+                );
+                return favoritedColors.some((colorRef) => {
+                  return hex === readField("hex", colorRef);
+                });
+              },
+            },
+          },
+        },
+      },
+    }),
+    uri: "http://localhost:4000",
+  });
 }
 
 export default App;

--- a/development/client/src/index.js
+++ b/development/client/src/index.js
@@ -4,43 +4,7 @@ import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
-import {
-  ApolloClient,
-  InMemoryCache,
-  ApolloProvider,
-  makeReference,
-} from "@apollo/client";
-
-const client = new ApolloClient({
-  cache: new InMemoryCache({
-    typePolicies: {
-      Color: {
-        keyFields: ["hex"],
-        fields: {
-          saved: {
-            read(_, { readField }) {
-              const hex = readField("hex");
-              const favoritedColors = readField(
-                "favoritedColors",
-                makeReference("ROOT_QUERY")
-              );
-              return favoritedColors.some((colorRef) => {
-                return hex === readField("hex", colorRef);
-              });
-            },
-          },
-        },
-      },
-    },
-  }),
-  uri: "http://localhost:4000",
-});
-
-createRoot(document.getElementById("root")).render(
-  <ApolloProvider client={client}>
-    <App />
-  </ApolloProvider>
-);
+createRoot(document.getElementById("root")).render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -85,7 +85,7 @@ export function createDevtoolsMachine({ actions }: { actions: Actions }) {
             timeout: "timedout",
             clientNotFound: "notFound",
           },
-          entry: "unsubscribeFromAll",
+          entry: ["unsubscribeFromAll", "connectToClient"],
         },
         timedout: {},
         notFound: {

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -19,6 +19,7 @@ const devtoolsMachine = interpret(
     actions: {
       connectToClient: () => {
         clientPort.send({ type: "connectToClient" });
+        startConnectTimeout();
       },
       startRequestInterval: () => {
         clearTimeout(connectTimeoutId);

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -19,7 +19,7 @@ import {
   getMutations,
   getMainDefinition,
 } from "./helpers";
-import type { QueryResult } from "../../types";
+import type { QueryResult, SafeAny } from "../../types";
 import { getPrivateAccess } from "../../privateAccess";
 import type { JSONObject } from "../../application/types/json";
 import { createWindowActor } from "../actor";
@@ -33,7 +33,7 @@ declare global {
   type TCache = any;
 
   interface Window {
-    __APOLLO_CLIENT__: ApolloClient<TCache>;
+    __APOLLO_CLIENT__?: ApolloClient<TCache>;
     [DEVTOOLS_KEY]?: {
       push(client: ApolloClient<any>): void;
     };
@@ -245,8 +245,31 @@ function findClient() {
   initializeDevtoolsHook(); // call immediately to reduce lag if devtools are already available
 }
 
+function watchForClientTermination(client: ApolloClient<any>) {
+  const originalStop = client.stop;
+
+  client.stop = () => {
+    knownClients.delete(client);
+
+    if (window.__APOLLO_CLIENT__ === client) {
+      window.__APOLLO_CLIENT__ = undefined;
+    }
+
+    if (hook.ApolloClient === client) {
+      hook.ApolloClient = undefined;
+    }
+
+    tab.send({ type: "disconnectFromDevtools" });
+    originalStop.call(client);
+  };
+}
+
 function registerClient(client: ApolloClient<any>) {
-  knownClients.add(client);
+  if (!knownClients.has(client)) {
+    knownClients.add(client);
+    watchForClientTermination(client);
+  }
+
   hook.ApolloClient = client;
   // TODO: Repurpose this callback. The message it sent was not listened by
   // anything, so the broadcast was useless. Currently the devtools rely on

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -22,7 +22,6 @@ import {
 import type { QueryResult } from "../../types";
 import { getPrivateAccess } from "../../privateAccess";
 import type { JSONObject } from "../../application/types/json";
-import type { FetchPolicy } from "../../application/components/Explorer/Explorer";
 import { createWindowActor } from "../actor";
 import type { ClientMessage, DevtoolsRPCMessage } from "../messages";
 import { createWindowMessageAdapter } from "../messageAdapters";

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -19,7 +19,7 @@ import {
   getMutations,
   getMainDefinition,
 } from "./helpers";
-import type { QueryResult, SafeAny } from "../../types";
+import type { QueryResult } from "../../types";
 import { getPrivateAccess } from "../../privateAccess";
 import type { JSONObject } from "../../application/types/json";
 import { createWindowActor } from "../actor";


### PR DESCRIPTION
Fixes #1240

Handles when `client.stop` is called and properly disconnects the client instance from devtools and performs some cleanup in the content script. This also makes it possible to track newly created clients after a previous client was terminated.