### PR TITLE
Fix memory leak issue with dev tools

### DIFF
--- a/.changeset/rich-balloons-prove.md
+++ b/.changeset/rich-balloons-prove.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fixed a memory leak issue with devtools

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -18,9 +18,6 @@ export function createPortMessageAdapter<
   return {
     addListener(listener) {
       port.onMessage.addListener(listener);
-      port.onDisconnect.addListener(() => {
-        port.onMessage.removeListener(listener);
-      });
 
       return () => {
         port.onMessage.removeListener(listener);


### PR DESCRIPTION
This is to fix the memory leak identified in #1332

Each copy of client data to extension is wrapped inside a promise, 
and this data is supposed to be removed and GCed but right now it's not. 

in src/extension/messageAdapters.ts `createPortMessageAdapter` 
the line `port.onDisconnect.addListener` creates 
a closure that holds the reference to `handler` passed in, and only release when disconnect, 
which may not happen very soon. 
And in src/extension/rpc.ts `createRpcClient` function, the the handler holds 
a reference to the promise that get data from client side.
so the promise data never got garbage collected.

Removed this event handler from onDisconnect to fix the memory leak issue.

May need to address how to properly remove it in `onDisconnect`, but it's lower priority. 
closes #1332