### PR TITLE
Change list styles to make the text a bit smaller

### DIFF
--- a/.changeset/silly-hats-tease.md
+++ b/.changeset/silly-hats-tease.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Revert some changes to the list styles that made the text feel huge

--- a/src/application/components/List.tsx
+++ b/src/application/components/List.tsx
@@ -9,7 +9,7 @@ export function List({ className, ...props }: ListProps) {
       {...props}
       className={clsx(
         className,
-        "overflow-y-auto flex flex-col gap-2 list-none"
+        "overflow-y-auto flex flex-col gap-1 list-none"
       )}
     />
   );

--- a/src/application/components/ListItem.tsx
+++ b/src/application/components/ListItem.tsx
@@ -19,7 +19,7 @@ export function ListItem({
       tabIndex={0}
       className={twMerge(
         className,
-        "text-md text-primary dark:text-primary-dark",
+        "text-sm text-primary dark:text-primary-dark",
         "transition-colors duration-200",
         "border-2 border-transparent flex items-center rounded-md cursor-pointer py-2 px-4",
         "focus-visible:outline-none",


### PR DESCRIPTION
#1349 updated the list styles to better match the styles we have for lists in Studio UI. We had some feedback that this was a bit too large (and I agree) so this PR reverts the change to make the text a bit smaller. We are naturally working with less screen real estate, so the more we can fit in the view, the better.

**Before**
<img width="1512" alt="Screenshot 2024-05-08 at 4 10 39 PM" src="https://github.com/apollographql/apollo-client-devtools/assets/565661/a72f4426-57e8-424d-8dc3-daeed52ea82d">

**After**
<img width="1511" alt="Screenshot 2024-05-08 at 4 10 19 PM" src="https://github.com/apollographql/apollo-client-devtools/assets/565661/018fa90c-0cb1-4e55-96e2-7ea3a752f92a">
