### PR TITLE
Modify legacy registration mechanism

### DIFF
--- a/.changeset/young-brooms-protect.md
+++ b/.changeset/young-brooms-protect.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Use `Object.defineProperty` to register legacy clients to avoid the need to search for the client in a loop in initialization.

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -308,8 +308,11 @@ Object.defineProperty(window, "__APOLLO_CLIENT__", {
   get() {
     return globalClient;
   },
-  set(client: ApolloClient<SafeAny>) {
-    registerClient(client);
+  set(client: ApolloClient<SafeAny> | undefined) {
+    if (client) {
+      registerClient(client);
+    }
+
     globalClient = client;
   },
 });

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -317,5 +317,3 @@ Object.defineProperty(window, "__APOLLO_CLIENT__", {
 if (globalClient) {
   registerClient(globalClient);
 }
-
-findClient();

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -91,12 +91,6 @@ window.onbeforeunload = () => {
   tab.send({ type: "disconnectFromDevtools" });
 };
 
-window.addEventListener("load", () => {
-  if (hook.ApolloClient) {
-    sendHookDataToDevTools("connectToDevtools");
-  }
-});
-
 function getClientData() {
   // We need to JSON stringify the data here in case the cache contains
   // references to irregular data such as `URL` instances which are not

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -310,7 +310,11 @@ Object.defineProperty(window, "__APOLLO_CLIENT__", {
   },
   set(client: ApolloClient<SafeAny> | undefined) {
     if (client) {
-      registerClient(client);
+      // We call this in a setTimeout because the client is not fully
+      // instantiated before the property on window is assigned since it
+      // connects from the constructor of ApolloClient. This allows
+      // initialization to finish before we register it.
+      setTimeout(() => registerClient(client));
     }
 
     globalClient = client;


### PR DESCRIPTION
This is a precursor to some work I'm doing to make client discovery a bit less chaotic. Uses `Object.defineProperty` for the global property to monitor its setter and register the client with the devtools.