### PR TITLE
Fix intermittent issue where a page refresh or navigation might mistakenly connect but show no data

### DIFF
--- a/.changeset/dirty-rules-deny.md
+++ b/.changeset/dirty-rules-deny.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix intermittent issue where data would not show up in the devtools after refreshing the page while the Apollo devtools panel is open.

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -130,6 +130,7 @@ export const App = () => {
     const dismiss = BannerAlert.show(ALERT_CONFIGS[state]);
 
     if (state === "connected") {
+      setClientNotFoundModalOpen(false);
       timeout = setTimeout(dismiss, 2500);
     }
 

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -87,7 +87,7 @@ export function createDevtoolsMachine({ actions }: { actions: Actions }) {
             timeout: "timedout",
             clientNotFound: "notFound",
           },
-          entry: ["unsubscribeFromAll", "connectToClient"],
+          entry: ["unsubscribeFromAll"],
         },
         timedout: {},
         notFound: {

--- a/src/application/machines.ts
+++ b/src/application/machines.ts
@@ -93,6 +93,7 @@ export function createDevtoolsMachine({ actions }: { actions: Actions }) {
         notFound: {
           on: {
             retry: "retrying",
+            connect: "connected",
           },
           entry: "unsubscribeFromAll",
         },

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -99,6 +99,7 @@ clientPort.on("disconnectFromDevtools", () => {
 });
 
 clientPort.on("clientNotFound", () => {
+  clearTimeout(connectTimeoutId);
   devtoolsMachine.send("clientNotFound");
 });
 

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -84,6 +84,14 @@ clientPort.on("connectToClientTimeout", () => {
 
 clientPort.on("disconnectFromDevtools", () => {
   devtoolsMachine.send("disconnect");
+
+  // Give it 10 seconds to register a new client before we set it to
+  // clientNotFound
+  setTimeout(() => {
+    if (devtoolsMachine.state.value === "disconnected") {
+      devtoolsMachine.send("clientNotFound");
+    }
+  }, 10_000);
 });
 
 clientPort.on("clientNotFound", () => {

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -80,9 +80,8 @@ clientPort.on("connectToDevtools", (message) => {
   });
 });
 
-clientPort.on("registerClient", async () => {
-  const clientContext = await rpcClient.request("getClientOperations");
-  devtoolsMachine.send({ type: "connect", clientContext });
+clientPort.on("registerClient", (message) => {
+  devtoolsMachine.send({ type: "connect", clientContext: message.payload });
 });
 
 clientPort.on("disconnectFromDevtools", () => {

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -85,10 +85,6 @@ clientPort.on("registerClient", async () => {
   devtoolsMachine.send({ type: "connect", clientContext });
 });
 
-clientPort.on("connectToClientTimeout", () => {
-  devtoolsMachine.send("timeout");
-});
-
 clientPort.on("disconnectFromDevtools", () => {
   clearTimeout(disconnectTimeoutId);
   devtoolsMachine.send("disconnect");

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -73,6 +73,11 @@ clientPort.on("connectToDevtools", (message) => {
   });
 });
 
+clientPort.on("registerClient", async () => {
+  const clientContext = await rpcClient.request("getClientOperations");
+  devtoolsMachine.send({ type: "connect", clientContext });
+});
+
 clientPort.on("connectToClientTimeout", () => {
   devtoolsMachine.send("timeout");
 });

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -82,6 +82,7 @@ type ExplorerSubscriptionTerminationMessage = {
 };
 
 export type ClientMessage =
+  | { type: "registerClient" }
   | { type: "clientNotFound" }
   | { type: "connectToClient" }
   | { type: "connectToClientTimeout" }

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -82,7 +82,7 @@ type ExplorerSubscriptionTerminationMessage = {
 };
 
 export type ClientMessage =
-  | { type: "registerClient" }
+  | { type: "registerClient"; payload: ClientContext }
   | { type: "clientNotFound" }
   | { type: "connectToClient" }
   | {

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -85,7 +85,6 @@ export type ClientMessage =
   | { type: "registerClient" }
   | { type: "clientNotFound" }
   | { type: "connectToClient" }
-  | { type: "connectToClientTimeout" }
   | {
       type: "connectToDevtools";
       payload: ClientContext;

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -117,16 +117,12 @@ function getClientData() {
 
 handleRpc("getClientOperations", getClientData);
 
-function sendHookDataToDevTools(eventName: "connectToDevtools") {
-  tab.send({
-    type: eventName,
-    payload: getClientData(),
-  });
-}
-
 tab.on("connectToClient", () => {
   if (hook.ApolloClient) {
-    sendHookDataToDevTools("connectToDevtools");
+    tab.send({
+      type: "connectToDevtools",
+      payload: getClientData(),
+    });
   } else {
     findClient();
   }

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -261,7 +261,7 @@ function registerClient(client: ApolloClient<any>) {
   if (!knownClients.has(client)) {
     knownClients.add(client);
     watchForClientTermination(client);
-    tab.send({ type: "registerClient" });
+    tab.send({ type: "registerClient", payload: getClientData() });
   }
 
   hook.ApolloClient = client;

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -119,10 +119,7 @@ handleRpc("getClientOperations", getClientData);
 
 tab.on("connectToClient", () => {
   if (hook.ApolloClient) {
-    tab.send({
-      type: "connectToDevtools",
-      payload: getClientData(),
-    });
+    tab.send({ type: "connectToDevtools", payload: getClientData() });
   } else {
     findClient();
   }

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -268,6 +268,7 @@ function registerClient(client: ApolloClient<any>) {
   if (!knownClients.has(client)) {
     knownClients.add(client);
     watchForClientTermination(client);
+    tab.send({ type: "registerClient" });
   }
 
   hook.ApolloClient = client;
@@ -283,9 +284,6 @@ function registerClient(client: ApolloClient<any>) {
   // });
 
   clearInterval(interval);
-  // incase initial update was missed because the client wasn't ready, send the create devtools event.
-  // devtools checks to see if it's already created, so this won't create duplicate tabs
-  sendHookDataToDevTools("connectToDevtools");
   loadErrorCodes(rpcClient, client.version);
 }
 

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -117,9 +117,16 @@ function getClientData() {
 
 handleRpc("getClientOperations", getClientData);
 
+function sendHookDataToDevTools(eventName: "connectToDevtools") {
+  tab.send({
+    type: eventName,
+    payload: getClientData(),
+  });
+}
+
 tab.on("connectToClient", () => {
   if (hook.ApolloClient) {
-    tab.send({ type: "connectToDevtools", payload: getClientData() });
+    sendHookDataToDevTools("connectToDevtools");
   } else {
     findClient();
   }

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -23,6 +23,7 @@ devtools.forward("connectToClient", tab);
 devtools.forward("explorerSubscriptionTermination", tab);
 devtools.forward("explorerRequest", tab);
 
+tab.forward("registerClient", devtools);
 tab.forward("clientNotFound", devtools);
 tab.forward("connectToDevtools", devtools);
 tab.forward("disconnectFromDevtools", devtools);


### PR DESCRIPTION
Our current disconnect event sent to the devtools prompts devtools to try and connect to the client again by sending the `connectToClient` message. This caused some weird issues where sometimes that event was triggered so fast that it re-discovered the old client before the page was fully unloaded. At times this seemed to cause issues where it was reported that the client was connected, but you saw no data.

This PR introduces a new `registerClient` event sent by the content script that is fired when a client registered with the devtools to distinctly identify the event as such. Now when a disconnect happens, rather than pinging the content script over and over to try and determine if a client is connected, it will instead start a new timer, wait 10 seconds, and if the `registerClient` event hasn't occured within that time, will set itself to the "not found" state. This makes this behavior much more reliable between page refreshes and navigation.

This PR also makes a small improvement by detecting if the client is able to connect again after it has found itself in the "not found" state. If, for example, you navigate to a page without Apollo loaded, then navigate back using the back button, it will re-connect itself and show the data in the devtools without first having to click the "retry" button.

If you want to validate some cases yourself, try doing these few things:
* Reloading the page
* Navigate to url without Apollo (e.g. github.com)
  * Ensure it shows "disconnected", then you get "not found" after ~10 sec
  * Hit the back button, ensure it reconnects to the app that has an Apollo Client instance
  * Hit forward, should see "disconnected"
  * Hit back before the "not found" message is shown. You should see it connect again.