### PR TITLE
Remove unneeded setup/teardown of message forwarding in the panel

### DIFF
--- a/.changeset/little-flowers-float.md
+++ b/.changeset/little-flowers-float.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Remove unneeded setup/teardown of message forwarding in the panel and instead only setup the forwarding once.

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -122,10 +122,6 @@ async function createDevtoolsPanel() {
     "panel.html"
   );
 
-  let removeExplorerForward: () => void;
-  let removeSubscriptionTerminationListener: () => void;
-  let removeExplorerListener: () => void;
-
   panel.onShown.addListener((window) => {
     panelWindow = getPanelActor(window);
 
@@ -144,6 +140,10 @@ async function createDevtoolsPanel() {
         panelWindow.send({ type: "devtoolsStateChanged", state: value });
       });
 
+      clientPort.forward("explorerResponse", panelWindow);
+      panelWindow.forward("explorerRequest", clientPort);
+      panelWindow.forward("explorerSubscriptionTermination", clientPort);
+
       connectedToPanel = true;
     }
 
@@ -151,23 +151,12 @@ async function createDevtoolsPanel() {
       unsubscribers.add(startRequestInterval());
     }
 
-    removeExplorerForward = clientPort.forward("explorerResponse", panelWindow);
-    removeExplorerListener = panelWindow.forward("explorerRequest", clientPort);
-    removeSubscriptionTerminationListener = panelWindow.forward(
-      "explorerSubscriptionTermination",
-      clientPort
-    );
-
     panelHidden = false;
   });
 
   panel.onHidden.addListener(() => {
     panelHidden = true;
     unsubscribeFromAll();
-
-    removeExplorerForward();
-    removeSubscriptionTerminationListener();
-    removeExplorerListener();
   });
 }
 


### PR DESCRIPTION
Small optimization to the setup of the panel. We only need to create the port forwarding once rather than setting it up then tearing it down anytime the user navigates away from the devtools tab. Since we no longer poll for changes as of #1379 this was even more unnecessary.