### PR TITLE
Automatically reconnect the ports when they disconnect

### DIFF
--- a/.changeset/late-crabs-rule.md
+++ b/.changeset/late-crabs-rule.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Automatically reconnect the ports when they disconnect.

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -103,14 +103,6 @@ export function createActor<
   };
 }
 
-export function createPortActor<
-  Messages extends MessageFormat = {
-    type: "Error: Pass <Messages> to `createPortActor<Messages>()`";
-  },
->(port: browser.Runtime.Port) {
-  return createActor<Messages>(createPortMessageAdapter(port));
-}
-
 export function createWindowActor<
   Messages extends MessageFormat = {
     type: "Error: Pass <Messages> to `createWindowActor<Messages>()`";

--- a/src/extension/background/errorcodes.ts
+++ b/src/extension/background/errorcodes.ts
@@ -11,7 +11,7 @@ export type ErrorCodesHandler = {
 browser.runtime.onConnect.addListener((port) => {
   if (port.name === "tab") {
     const handleRpc = createRpcHandler<ErrorCodesHandler>(
-      createPortMessageAdapter(port)
+      createPortMessageAdapter(() => port)
     );
     handleRpc("getErrorCodes", (version) => {
       if (version in allErrorCodes.byVersion) {

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -10,21 +10,58 @@ export interface MessageAdapter<
   postMessage: (message: PostMessageFormat) => void;
 }
 
+interface PortMessageAdapter<
+  PostMessageFormat extends ApolloClientDevtoolsMessage<
+    Record<string, unknown>
+  >,
+> extends MessageAdapter<PostMessageFormat> {
+  replacePort: (port: browser.Runtime.Port) => void;
+}
+
 export function createPortMessageAdapter<
   PostMessageFormat extends Record<string, unknown> = Record<string, unknown>,
 >(
   port: browser.Runtime.Port
-): MessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
+): PortMessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
+  let currentPort = port;
+  const listeners = new Set<(message: unknown) => void>();
+
+  function handleDisconnect() {
+    listeners.forEach((listener) => {
+      currentPort.onMessage.removeListener(listener);
+    });
+  }
+
+  function initializePort() {
+    listeners.forEach((listener) =>
+      currentPort.onMessage.addListener(listener)
+    );
+    currentPort.onDisconnect.addListener(handleDisconnect);
+  }
+
+  initializePort();
+
   return {
     addListener(listener) {
-      port.onMessage.addListener(listener);
+      listeners.add(listener);
+      currentPort.onMessage.addListener(listener);
 
       return () => {
-        port.onMessage.removeListener(listener);
+        listeners.delete(listener);
+        currentPort.onMessage.removeListener(listener);
       };
     },
     postMessage(message) {
-      return port.postMessage(message);
+      return currentPort.postMessage(message);
+    },
+    replacePort(port) {
+      listeners.forEach((listener) =>
+        currentPort.onMessage.removeListener(listener)
+      );
+      currentPort.onDisconnect.removeListener(handleDisconnect);
+      currentPort = port;
+
+      initializePort();
     },
   };
 }

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -15,25 +15,23 @@ export function createPortMessageAdapter<
 >(
   createPort: () => browser.Runtime.Port
 ): MessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
-  let currentPort = createPort();
+  let port = createPort();
   const listeners = new Set<(message: unknown) => void>();
 
   function handleDisconnect() {
     listeners.forEach((listener) => {
-      currentPort.onMessage.removeListener(listener);
+      port.onMessage.removeListener(listener);
     });
 
-    currentPort.onDisconnect.removeListener(handleDisconnect);
-    currentPort = createPort();
+    port.onDisconnect.removeListener(handleDisconnect);
+    port = createPort();
 
     initializePort();
   }
 
   function initializePort() {
-    listeners.forEach((listener) =>
-      currentPort.onMessage.addListener(listener)
-    );
-    currentPort.onDisconnect.addListener(handleDisconnect);
+    listeners.forEach((listener) => port.onMessage.addListener(listener));
+    port.onDisconnect.addListener(handleDisconnect);
   }
 
   initializePort();
@@ -41,15 +39,15 @@ export function createPortMessageAdapter<
   return {
     addListener(listener) {
       listeners.add(listener);
-      currentPort.onMessage.addListener(listener);
+      port.onMessage.addListener(listener);
 
       return () => {
         listeners.delete(listener);
-        currentPort.onMessage.removeListener(listener);
+        port.onMessage.removeListener(listener);
       };
     },
     postMessage(message) {
-      return currentPort.postMessage(message);
+      return port.postMessage(message);
     },
   };
 }

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -10,21 +10,12 @@ import { createRPCBridge } from "../rpc";
 
 declare const __IS_FIREFOX__: boolean;
 
-const PORT_NAME = "tab";
-
-function handleDisconnect() {
-  const port = browser.runtime.connect({ name: PORT_NAME });
-  portAdapter.replacePort(port);
-  port.onDisconnect.addListener(handleDisconnect);
-}
-
-const port = browser.runtime.connect({ name: PORT_NAME });
-const portAdapter = createPortMessageAdapter(port);
+const portAdapter = createPortMessageAdapter(() =>
+  browser.runtime.connect({ name: "tab" })
+);
 
 const tab = createWindowActor<ClientMessage>(window);
 const devtools = createActor<ClientMessage>(portAdapter);
-
-port.onDisconnect.addListener(handleDisconnect);
 
 createRPCBridge(portAdapter, createWindowMessageAdapter(window));
 


### PR DESCRIPTION
When a port disconnects, we will now try to automatically reconnect it to the background script. This should help in situations where the browser might disconnect the service worker [due to inactivity](https://developer.chrome.com/docs/extensions/whats-new#m110-sw-idle).