### PR TITLE
Fix issue where messages sent via the `window` adapter could be echoed back to the sender

### DIFF
--- a/.changeset/tricky-rats-hang.md
+++ b/.changeset/tricky-rats-hang.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix issue where messages sent via the `window` adapter could be echoed back to the sender.

--- a/src/extension/__tests__/actor.test.ts
+++ b/src/extension/__tests__/actor.test.ts
@@ -37,6 +37,7 @@ test("sends messages to specified adapter in devtools message format", () => {
   actor.send({ type: "test", payload: "Hello" });
 
   expect(adapter.postMessage).toHaveBeenCalledWith({
+    id: expect.any(String),
     source: "apollo-client-devtools",
     type: MessageType.Event,
     message: {
@@ -237,6 +238,7 @@ test("forwards messages to another actor", () => {
 
   expect(actorAdapter.postMessage).toHaveBeenCalledTimes(1);
   expect(actorAdapter.postMessage).toHaveBeenCalledWith({
+    id: expect.any(String),
     source: "apollo-client-devtools",
     type: MessageType.Event,
     message: {
@@ -249,6 +251,7 @@ test("forwards messages to another actor", () => {
 
   expect(actorAdapter.postMessage).toHaveBeenCalledTimes(2);
   expect(actorAdapter.postMessage).toHaveBeenCalledWith({
+    id: expect.any(String),
     source: "apollo-client-devtools",
     type: MessageType.Event,
     message: { type: "disconnect" },

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -6,6 +6,7 @@ import { MessageType, isEventMessage } from "./messages";
 import type { NoInfer } from "../types";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
+import { createId } from "../utils/createId";
 
 export interface Actor<Messages extends MessageFormat> {
   on: <TName extends Messages["type"]>(
@@ -89,6 +90,7 @@ export function createActor<
     on,
     send: (message) => {
       adapter.postMessage({
+        id: createId(),
         source: "apollo-client-devtools",
         type: MessageType.Event,
         message,

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -81,6 +81,9 @@ export function createWindowMessageAdapter<
     },
     postMessage(message) {
       sentMessageIds.add(message.id);
+      // Avoid memory leaks by always cleaning up this ID in case this message
+      // adapter doesn't have a listener attached to it.
+      setTimeout(() => sentMessageIds.delete(message.id), 10);
       window.postMessage(message, "*");
     },
   };

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -57,9 +57,19 @@ export function createWindowMessageAdapter<
 >(
   window: Window
 ): MessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
+  const sentMessageIds = new Set<string>();
+
   return {
     addListener(listener) {
       function handleEvent({ data }: MessageEvent) {
+        // We don't want to trigger listeners for a message sent from this
+        // adapter. This prevents situations where e.g. rpc messages were
+        // accidentally echoing the rpc request back to the sender rather
+        // than just the rpc response.
+        if (sentMessageIds.has(data.id)) {
+          return sentMessageIds.delete(data.id);
+        }
+
         listener(data);
       }
 
@@ -70,6 +80,7 @@ export function createWindowMessageAdapter<
       };
     },
     postMessage(message) {
+      sentMessageIds.add(message.id);
       window.postMessage(message, "*");
     },
   };

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -51,6 +51,7 @@ export type RPCMessage<
 export type ApolloClientDevtoolsEventMessage<
   Message extends Record<string, unknown> = Record<string, unknown>,
 > = {
+  id: string;
   source: "apollo-client-devtools";
   type: MessageType.Event;
   message: Message;

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -1,4 +1,5 @@
 import type { NoInfer, SafeAny } from "../types";
+import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
@@ -164,15 +165,4 @@ export function createRPCBridge(
     removeListener1();
     removeListener2();
   };
-}
-
-function createId() {
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  const values = new Uint8Array(10);
-  crypto.getRandomValues(values);
-
-  return Array.from(values)
-    .map((number) => chars[number % chars.length])
-    .join("");
 }

--- a/src/utils/createId.ts
+++ b/src/utils/createId.ts
@@ -1,0 +1,10 @@
+export function createId() {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const values = new Uint8Array(10);
+  crypto.getRandomValues(values);
+
+  return Array.from(values)
+    .map((number) => chars[number % chars.length])
+    .join("");
+}


### PR DESCRIPTION
While working on the feature to work with multiple client instances on a page, I noticed that some unnecessary messages were moving between the content and devtools scripts. Digging further, I saw that the rpc requests were getting echoed back to the sender of the request.