### PR TITLE
Use `queryId` as `id` for queries

### DIFF
--- a/src/application/__tests__/AppProvider.test.tsx
+++ b/src/application/__tests__/AppProvider.test.tsx
@@ -32,6 +32,7 @@ describe("<AppProvider />", () => {
   describe("getQueryData", () => {
     test("returns expected query data", () => {
       const queryData: QueryDetails = {
+        id: "1",
         document: gql`
           query GetColorByHex {
             someQuery {
@@ -50,10 +51,10 @@ describe("<AppProvider />", () => {
         networkStatus: NetworkStatus.ready,
       };
 
-      const data = getQueryData(queryData, 0);
+      const data = getQueryData(queryData);
 
       expect(data).toEqual({
-        id: 0,
+        id: 1,
         __typename: "WatchedQuery",
         name: "GetColorByHex",
         queryString:
@@ -75,10 +76,11 @@ describe("<AppProvider />", () => {
 
     test("ignores IntrospectionQuery", () => {
       const queryData: QueryDetails = {
+        id: "1",
         document: gql(getIntrospectionQuery()),
       };
 
-      const data = getQueryData(queryData, 0);
+      const data = getQueryData(queryData);
       expect(data).toBeUndefined();
     });
   });

--- a/src/application/components/Queries/Queries.tsx
+++ b/src/application/components/Queries/Queries.tsx
@@ -61,7 +61,7 @@ interface QueriesProps {
 }
 
 export const Queries = ({ explorerIFrame }: QueriesProps) => {
-  const [selected, setSelected] = useState<number>(0);
+  const [selected, setSelected] = useState(1);
   const { data } = useQuery(GET_WATCHED_QUERIES, { returnPartialData: true });
 
   const queries = data?.watchedQueries.queries ?? [];
@@ -76,7 +76,7 @@ export const Queries = ({ explorerIFrame }: QueriesProps) => {
   const pollInterval = selectedQuery?.pollInterval;
 
   if (!selectedQuery && queries.length > 0) {
-    setSelected(0);
+    setSelected(queries[0].id);
   }
 
   return (

--- a/src/application/components/Queries/__tests__/Queries.test.tsx
+++ b/src/application/components/Queries/__tests__/Queries.test.tsx
@@ -11,7 +11,7 @@ import { NetworkStatus } from "@apollo/client";
 describe("<Queries />", () => {
   const queries: GetQueries["watchedQueries"]["queries"] = [
     {
-      id: 0,
+      id: 1,
       __typename: "WatchedQuery",
       name: null,
       queryString: "query { hello }",
@@ -23,7 +23,7 @@ describe("<Queries />", () => {
       networkStatus: NetworkStatus.ready,
     },
     {
-      id: 1,
+      id: 2,
       __typename: "WatchedQuery",
       name: "GetColors",
       queryString: "query GetColors { colors }",

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -171,10 +171,7 @@ export const GET_MUTATIONS: TypedDocumentNode<
   }
 `;
 
-export function getQueryData(
-  query: QueryDetails,
-  key: number
-): WatchedQuery | undefined {
+export function getQueryData(query: QueryDetails): WatchedQuery | undefined {
   // TODO: The current designs do not account for non-cached data.
   // We need a workaround to show that data + we should surface
   // the FetchPolicy.
@@ -184,7 +181,7 @@ export function getQueryData(
   }
 
   return {
-    id: key,
+    id: Number(query.id),
     __typename: "WatchedQuery",
     name,
     queryString: print(query.document),

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -44,6 +44,7 @@ export interface SerializedError {
 }
 
 export type QueryDetails = {
+  id: string;
   document: DocumentNode;
   variables?: Variables;
   cachedData?: QueryData; // Not a member of the actual Apollo Client QueryInfo type
@@ -66,7 +67,7 @@ export function getQueries(
 ): QueryDetails[] {
   const queries: QueryDetails[] = [];
   if (observableQueries) {
-    observableQueries.forEach((oc) => {
+    observableQueries.forEach((oc, queryId) => {
       const observableQuery = getPrivateAccess(oc);
       const { document, variables } = observableQuery.queryInfo;
       const diff = observableQuery.queryInfo.getDiff();
@@ -80,6 +81,7 @@ export function getQueries(
       const { networkStatus, error } = observableQuery.getCurrentResult(false);
 
       queries.push({
+        id: queryId,
         document,
         variables,
         cachedData: diff.result,
@@ -139,6 +141,7 @@ export function getQueriesLegacy(
   queryMap: Map<
     string,
     {
+      queryId: string;
       document: DocumentNode;
       variables: Variables;
       diff: Cache.DiffResult<any>;
@@ -148,8 +151,9 @@ export function getQueriesLegacy(
 ): QueryDetails[] {
   let queries: QueryDetails[] = [];
   if (queryMap) {
-    queries = [...queryMap.values()].map(
-      ({ document, variables, diff, networkStatus }) => ({
+    queries = [...queryMap.entries()].map(
+      ([queryId, { document, variables, diff, networkStatus }]) => ({
+        id: queryId,
         document,
         variables,
         cachedData: diff?.result,

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -141,7 +141,6 @@ export function getQueriesLegacy(
   queryMap: Map<
     string,
     {
-      queryId: string;
       document: DocumentNode;
       variables: Variables;
       diff: Cache.DiffResult<any>;


### PR DESCRIPTION
Switches the value of `id` used for queries to the `queryId` its associated with in Apollo Client rather than its index in the map. This should allow us to build additional functionality in the future that targets the proper query rather than guessing based on its index in the map.