### PR TITLE
Fix issue where data would disappear after refreshing the page

### DIFF
--- a/.changeset/nine-walls-bathe.md
+++ b/.changeset/nine-walls-bathe.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix an issue where data would sometimes disappear a few seconds after refreshing the page with no way to recover the data afterward.

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -74,7 +74,7 @@ export const App = () => {
     devtoolsMachine.provide({
       actions: {
         resetStore: () => {
-          apolloClient.resetStore().catch(() => {});
+          apolloClient.clearStore().catch(() => {});
         },
       },
     })

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -36,7 +36,7 @@ import { isSnapshotRelease, parseSnapshotRelease } from "./utilities/github";
 import { Select } from "./components/Select";
 import { Divider } from "./components/Divider";
 import { useActorEvent } from "./hooks/useActorEvent";
-import { addClient, removeClient } from ".";
+import { removeClient } from ".";
 
 const APP_QUERY: TypedDocumentNode<AppQuery, AppQueryVariables> = gql`
   query AppQuery {

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -79,17 +79,23 @@ export const App = () => {
       },
     })
   );
-  const { data, client: apolloClient } = useQuery(APP_QUERY, {
-    errorPolicy: "all",
-  });
+  const {
+    data,
+    client: apolloClient,
+    refetch,
+  } = useQuery(APP_QUERY, { errorPolicy: "all" });
 
   useActorEvent("connectToDevtools", () => {
     send({ type: "connect" });
   });
 
-  useActorEvent("registerClient", (message) => {
+  useActorEvent("registerClient", () => {
     send({ type: "connect" });
-    addClient(message.payload);
+    // Unfortunately after we clear the store above, the query ends up "stuck"
+    // holding onto the old list of clients even if we manually write a cache
+    // update to properly resolve the list. Instead we refetch the list again to
+    // force the query to reload to ensure its in sync with the latest values.
+    refetch();
   });
 
   useActorEvent("clientTerminated", (message) => {

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -1,12 +1,7 @@
 import { useEffect } from "react";
 import { createRoot } from "react-dom/client";
-import type { Reference, TypedDocumentNode } from "@apollo/client";
-import {
-  ApolloClient,
-  ApolloProvider,
-  InMemoryCache,
-  gql,
-} from "@apollo/client";
+import type { Reference } from "@apollo/client";
+import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 import { SchemaLink } from "@apollo/client/link/schema";
 
 import { colorTheme, listenForThemeChange } from "./theme";
@@ -16,11 +11,6 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 
 import { getRpcClient } from "../extension/devtools/panelRpcClient";
 import { createSchemaWithRpcClient } from "./schema";
-import type { ApolloClientInfo } from "../types";
-import type {
-  UpdateClientsQuery,
-  UpdateClientsQueryVariables,
-} from "./types/gql";
 
 const rpcClient = getRpcClient();
 const schema = createSchemaWithRpcClient(rpcClient);
@@ -71,53 +61,6 @@ const cache = new InMemoryCache({
 });
 
 export const client = new ApolloClient({ cache, link });
-
-const UPDATE_CLIENTS_QUERY: TypedDocumentNode<
-  UpdateClientsQuery,
-  UpdateClientsQueryVariables
-> = gql`
-  query UpdateClientsQuery {
-    clients {
-      id
-      name
-      version
-      queries {
-        total
-      }
-      mutations {
-        total
-      }
-    }
-  }
-`;
-
-export const addClient = (clientData: ApolloClientInfo) => {
-  const result = client.readQuery({ query: UPDATE_CLIENTS_QUERY });
-  const clients = result?.clients ?? [];
-
-  client.writeQuery({
-    query: UPDATE_CLIENTS_QUERY,
-    data: {
-      clients: [
-        ...clients,
-        {
-          __typename: "Client",
-          id: clientData.id,
-          name: clientData.name ?? null,
-          version: clientData.version,
-          queries: {
-            __typename: "ClientQueries",
-            total: clientData.queryCount,
-          },
-          mutations: {
-            __typename: "ClientMutations",
-            total: clientData.mutationCount,
-          },
-        },
-      ],
-    },
-  });
-};
 
 export const removeClient = (clientId: string) => {
   client.cache.modify({

--- a/src/application/index.tsx
+++ b/src/application/index.tsx
@@ -54,9 +54,11 @@ const cache = new InMemoryCache({
       },
     },
     ClientQueries: {
+      keyFields: false,
       merge: true,
     },
     ClientMutations: {
+      keyFields: false,
       merge: true,
     },
     SerializedApolloError: {

--- a/src/application/types/gql.ts
+++ b/src/application/types/gql.ts
@@ -280,16 +280,3 @@ export type SerializedErrorAlertDisclosureItem_error = {
   name: string;
   stack: string | null;
 };
-
-export type UpdateClientsQueryVariables = Exact<{ [key: string]: never }>;
-
-export type UpdateClientsQuery = {
-  clients: Array<{
-    __typename: "Client";
-    id: string;
-    name: string | null;
-    version: string;
-    queries: { __typename: "ClientQueries"; total: number };
-    mutations: { __typename: "ClientMutations"; total: number };
-  }>;
-};

--- a/src/application/types/gql.ts
+++ b/src/application/types/gql.ts
@@ -281,10 +281,15 @@ export type SerializedErrorAlertDisclosureItem_error = {
   stack: string | null;
 };
 
-export type ClientFields = {
-  __typename: "Client";
-  id: string;
-  version: string;
-  queries: { __typename: "ClientQueries"; total: number };
-  mutations: { __typename: "ClientMutations"; total: number };
+export type UpdateClientsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type UpdateClientsQuery = {
+  clients: Array<{
+    __typename: "Client";
+    id: string;
+    name: string | null;
+    version: string;
+    queries: { __typename: "ClientQueries"; total: number };
+    mutations: { __typename: "ClientMutations"; total: number };
+  }>;
 };


### PR DESCRIPTION
Fixes #1452

#1418 did a bunch of refactoring work to reorganize how and where data was requested for the devtools. As part of that change, a GraphQL-like "server" was spun up through `SchemaLink` that used RPC calls to resolve data.

After refreshing the page, we'd put the devtools in a disconnected state and in doing so, would call `client.resetStore`. `resetStore` causes active queries to be refetched, and in doing so, we'd see RPC request timeouts in cases where the disconnect was caused by reloading the page since the content scripts had not yet been injected and could not receive the RPC request message. This timeout would cause the query to get put into an error mode, which would clear the query data and cause the UI to show nothing in the UI.

This fix changes to use `clearStore` instead of `resetStore` to prevent the RPC calls from firing when the content script was not yet ready to receive messages and instead will refetch the list of clients after the first client is registered again.

---

Ultimately I'd love to introduce a message queue so that we can queue up messages from either end of the devtools in the event the port is disconnected. Upon connecting, we can send queued messages through the queue to process them. This requires a bit more thought and work, so this fix should be sufficient for now.