### PR TITLE
Fix function serialization in `context`

### DIFF
--- a/.changeset/sharp-horses-explode.md
+++ b/.changeset/sharp-horses-explode.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix serialization of functions in context

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -133,6 +133,18 @@ function getQueryOptions(observableQuery: ObservableQuery) {
     delete queryOptions.nextFetchPolicy;
   }
 
+  if (queryOptions.context) {
+    queryOptions.context = JSON.parse(
+      JSON.stringify(queryOptions.context, (_key, value) => {
+        if (typeof value === "function") {
+          return `<function>`;
+        }
+
+        return value;
+      })
+    ) as Record<string, unknown>;
+  }
+
   return queryOptions;
 }
 


### PR DESCRIPTION
When testing this with Studio UI, I noticed that query counts were displayed, but queries were not. After investigating further, it looks like the message serialization wasn't able to handle some of the `context` objects in queries because functions are used for some of the values.

This PR ensures functions can be serialized by replacing them with a simple `<function>` string as a placeholder.