### PR TITLE
Remove unneeded initialization message + fix stale data issue on disconnect

### DIFF
--- a/.changeset/silver-dolphins-drive.md
+++ b/.changeset/silver-dolphins-drive.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Remove unneeded initialization message to determine if page had a client instance.

--- a/.changeset/six-pears-compare.md
+++ b/.changeset/six-pears-compare.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix issue when disconnecting from the client that would show stale data until reconnected.

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -89,10 +89,6 @@ export const App = () => {
     refetch,
   } = useQuery(APP_QUERY, { errorPolicy: "all" });
 
-  useActorEvent("connectToDevtools", () => {
-    send({ type: "connect" });
-  });
-
   useActorEvent("registerClient", () => {
     send({ type: "connect" });
     // Unfortunately after we clear the store above, the query ends up "stuck"

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -148,7 +148,7 @@ export const App = () => {
     if (clients.length) {
       send({ type: "connect" });
     }
-  }, [send, clients]);
+  }, [send, clients.length]);
 
   return (
     <>

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { TypedDocumentNode } from "@apollo/client";
 import { useReactiveVar, gql, useQuery } from "@apollo/client";
 import { useMachine } from "@xstate/react";
@@ -69,12 +69,16 @@ ${SECTIONS.apolloClientVersion}
 ${SECTIONS.devtoolsVersion}
 `;
 
+const stableEmptyClients: Required<AppQuery["clients"]> = [];
+const noop = () => {};
+
 export const App = () => {
   const [snapshot, send] = useMachine(
     devtoolsMachine.provide({
       actions: {
-        resetStore: () => {
-          apolloClient.clearStore().catch(() => {});
+        resetStore: async () => {
+          await apolloClient.clearStore().catch(noop);
+          refetch().catch(noop);
         },
       },
     })
@@ -131,7 +135,7 @@ export const App = () => {
   });
 
   const client = clientData?.client;
-  const clients = data?.clients ?? [];
+  const clients = data?.clients ?? stableEmptyClients;
   const clientIds = clients.map((c) => c.id);
 
   useActorEvent("panelHidden", () => stopPolling());
@@ -143,6 +147,12 @@ export const App = () => {
   ) {
     setSelectedClientId(clientIds[0]);
   }
+
+  useEffect(() => {
+    if (clients.length) {
+      send({ type: "connect" });
+    }
+  }, [send, clients]);
 
   return (
     <>

--- a/src/application/components/BannerAlert.tsx
+++ b/src/application/components/BannerAlert.tsx
@@ -1,10 +1,10 @@
 import clsx from "clsx";
 import { makeVar, useReactiveVar } from "@apollo/client";
 import type { ReactNode } from "react";
-import { LoadingSpinner } from "./Explorer/LoadingSpinner";
 import IconCheck from "@apollo/icons/default/IconCheck.svg";
 import IconError from "@apollo/icons/default/IconError.svg";
 import { AnimatePresence, motion } from "framer-motion";
+import { Spinner } from "./Spinner";
 
 const bannerVar = makeVar<BannerAlertConfig | null>(null);
 
@@ -37,7 +37,7 @@ export function BannerAlert() {
             }
           )}
         >
-          {banner.type === "loading" && <LoadingSpinner size="2xsmall" />}
+          {banner.type === "loading" && <Spinner size="xs" />}
           {banner.type === "success" && <IconCheck className="w-4" />}
           {banner.type === "error" && <IconError className="w-4" />}
           <div className="text-sm font-body flex-1">{banner.content}</div>

--- a/src/application/machines/devtoolsMachine.tsx
+++ b/src/application/machines/devtoolsMachine.tsx
@@ -22,7 +22,7 @@ export const devtoolsMachine = setup({
   actions: {
     openModal: assign({ modalOpen: true }),
     closeModal: assign({ modalOpen: false }),
-    connectToClient: () => {
+    notifyWaitingForConnection: () => {
       BannerAlert.show({
         type: "loading",
         content: "Waiting for client to connect...",
@@ -85,7 +85,7 @@ export const devtoolsMachine = setup({
         timeout: "timedout",
         clientNotFound: "notFound",
       },
-      entry: "connectToClient",
+      entry: "notifyWaitingForConnection",
       after: {
         connectTimeout: {
           target: "notFound",
@@ -97,7 +97,7 @@ export const devtoolsMachine = setup({
         connect: "connected",
         clientNotFound: "notFound",
       },
-      entry: ["connectToClient", "closeModal"],
+      entry: ["notifyWaitingForConnection", "closeModal"],
       after: {
         connectTimeout: {
           target: "notFound",

--- a/src/application/machines/devtoolsMachine.tsx
+++ b/src/application/machines/devtoolsMachine.tsx
@@ -1,7 +1,6 @@
 import { setup, assign } from "xstate";
 import IconSync from "@apollo/icons/small/IconSync.svg";
 import { BannerAlert } from "../components/BannerAlert";
-import { getPanelActor } from "../../extension/devtools/panelActor";
 import { Button } from "../components/Button";
 
 type Events =
@@ -26,14 +25,14 @@ export const devtoolsMachine = setup({
     connectToClient: () => {
       BannerAlert.show({
         type: "loading",
-        content: "Looking for client...",
+        content: "Waiting for client to connect...",
       });
     },
     closeBanner: BannerAlert.close,
     notifyDisconnected: () => {
       BannerAlert.show({
         type: "loading",
-        content: "Disconnected. Looking for client...",
+        content: "Disconnected. Waiting for client to connect...",
       });
     },
     notifyConnected: () => {

--- a/src/application/machines/devtoolsMachine.tsx
+++ b/src/application/machines/devtoolsMachine.tsx
@@ -28,8 +28,6 @@ export const devtoolsMachine = setup({
         type: "loading",
         content: "Looking for client...",
       });
-
-      getPanelActor(window).send({ type: "connectToClient" });
     },
     closeBanner: BannerAlert.close,
     notifyDisconnected: () => {

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -40,7 +40,6 @@ async function createDevtoolsPanel() {
       clientPort.forward("clientTerminated", panelWindow);
       clientPort.forward("connectToDevtools", panelWindow);
 
-      panelWindow.forward("connectToClient", clientPort);
       panelWindow.forward("explorerRequest", clientPort);
       panelWindow.forward("explorerSubscriptionTermination", clientPort);
 

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -38,7 +38,6 @@ async function createDevtoolsPanel() {
       clientPort.forward("explorerResponse", panelWindow);
       clientPort.forward("registerClient", panelWindow);
       clientPort.forward("clientTerminated", panelWindow);
-      clientPort.forward("connectToDevtools", panelWindow);
 
       panelWindow.forward("explorerRequest", clientPort);
       panelWindow.forward("explorerSubscriptionTermination", clientPort);

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -95,7 +95,6 @@ type ClientTerminatedMessage = {
 
 export type ClientMessage =
   | RegisterClientMessage
-  | { type: "connectToDevtools" }
   | ClientTerminatedMessage
   | ExplorerRequestMessage
   | ExplorerResponseMessage
@@ -107,7 +106,6 @@ export type PanelMessage =
   | ExplorerRequestMessage
   | ExplorerResponseMessage
   | ExplorerSubscriptionTerminationMessage
-  | { type: "connectToDevtools" }
   | { type: "pageNavigated" }
   | { type: "initializePanel" }
   | { type: "panelHidden" }

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -95,7 +95,6 @@ type ClientTerminatedMessage = {
 
 export type ClientMessage =
   | RegisterClientMessage
-  | { type: "connectToClient" }
   | { type: "connectToDevtools" }
   | ClientTerminatedMessage
   | ExplorerRequestMessage
@@ -110,7 +109,6 @@ export type PanelMessage =
   | ExplorerSubscriptionTerminationMessage
   | { type: "connectToDevtools" }
   | { type: "pageNavigated" }
-  | { type: "connectToClient" }
   | { type: "initializePanel" }
   | { type: "panelHidden" }
   | { type: "panelShown" };

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -160,12 +160,6 @@ function getClientById(clientId: string) {
   return client;
 }
 
-tab.on("connectToClient", () => {
-  if (globalClient) {
-    tab.send({ type: "connectToDevtools" });
-  }
-});
-
 tab.on("explorerRequest", (message) => {
   const {
     clientId,

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -23,7 +23,6 @@ devtools.forward("explorerSubscriptionTermination", tab);
 devtools.forward("explorerRequest", tab);
 
 tab.forward("registerClient", devtools);
-tab.forward("connectToDevtools", devtools);
 tab.forward("clientTerminated", devtools);
 tab.forward("explorerResponse", devtools);
 

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -19,7 +19,6 @@ const devtools = createActor<ClientMessage>(portAdapter);
 
 createRPCBridge(portAdapter, createWindowMessageAdapter(window));
 
-devtools.forward("connectToClient", tab);
 devtools.forward("explorerSubscriptionTermination", tab);
 devtools.forward("explorerRequest", tab);
 


### PR DESCRIPTION
I found an opportunity to remove the unneeded `connectToDevtools` and `connectToClient` messages since we are now fetching the list of clients when opening devtools for the first time. We can use the result of this query to determine if we are connected by simply seeing if we get back at least 1 client.

This PR also fixes the issue where disconnecting from a client that was previously connected would show its stale data on screen until another client connected to the devtools. This is done by refetching the list of clients after we clear the store to ensure the `useQuery` hook is refreshed with the latest data.