### PR TITLE
Create single message bridge and simplify message types

### DIFF
--- a/.changeset/lazy-teachers-roll.md
+++ b/.changeset/lazy-teachers-roll.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Create a universal message bridge to handle both actor and rpc messages.

--- a/src/extension/__tests__/actor.test.ts
+++ b/src/extension/__tests__/actor.test.ts
@@ -222,38 +222,3 @@ test("re-adds listener on adapter when subscribing actor listener after disconne
   actor.on("connect", handleConnect);
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 });
-
-test("forwards messages to another actor", () => {
-  type Message = { type: "connect"; payload: string } | { type: "disconnect" };
-
-  const proxyAdapter = createTestAdapter<Message>();
-  const actorAdapter = createTestAdapter<Message>();
-  const proxy = createActor<Message>(proxyAdapter);
-  const actor = createActor<Message>(actorAdapter);
-
-  proxy.forward("connect", actor);
-  proxy.forward("disconnect", actor);
-
-  proxyAdapter.simulateDevtoolsMessage({ type: "connect", payload: "Hello!" });
-
-  expect(actorAdapter.postMessage).toHaveBeenCalledTimes(1);
-  expect(actorAdapter.postMessage).toHaveBeenCalledWith({
-    id: expect.any(String),
-    source: "apollo-client-devtools",
-    type: MessageType.Event,
-    message: {
-      type: "connect",
-      payload: "Hello!",
-    },
-  });
-
-  proxyAdapter.simulateDevtoolsMessage({ type: "disconnect" });
-
-  expect(actorAdapter.postMessage).toHaveBeenCalledTimes(2);
-  expect(actorAdapter.postMessage).toHaveBeenCalledWith({
-    id: expect.any(String),
-    source: "apollo-client-devtools",
-    type: MessageType.Event,
-    message: { type: "disconnect" },
-  });
-});

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -602,21 +602,3 @@ test("unsubscribes connection on bridge when calling returned function", () => {
   });
   expect(adapter1.postMessage).not.toHaveBeenCalled();
 });
-
-test.each([MessageType.Event])(
-  "does not forward %s messages",
-  (messageType) => {
-    const adapter1 = createTestAdapter();
-    const adapter2 = createTestAdapter();
-
-    createRPCBridge(adapter1, adapter2);
-
-    adapter1.simulateMessage({
-      id: 1,
-      type: messageType,
-      payload: { type: "add", params: { x: 1, y: 2 } },
-    });
-
-    expect(adapter2.postMessage).not.toHaveBeenCalled();
-  }
-);

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -1,9 +1,10 @@
 import type { DistributiveOmit } from "../../types";
 import { RPC_MESSAGE_TIMEOUT } from "../errorMessages";
 import type { MessageAdapter } from "../messageAdapters";
+import { createMessageBridge } from "../messageAdapters";
 import type { RPCMessage, RPCRequestMessage } from "../messages";
 import { MessageType } from "../messages";
-import { createRPCBridge, createRpcClient, createRpcHandler } from "../rpc";
+import { createRpcClient, createRpcHandler } from "../rpc";
 
 interface TestAdapter extends MessageAdapter<RPCMessage> {
   mocks: { listeners: Set<(message: unknown) => void>; messages: unknown[] };
@@ -524,7 +525,7 @@ test("forwards rpc messages from one adapter to another with bridge", () => {
   const adapter1 = createTestAdapter();
   const adapter2 = createTestAdapter();
 
-  createRPCBridge(adapter1, adapter2);
+  createMessageBridge(adapter1, adapter2);
 
   adapter1.simulateRPCMessage({
     id: "abc",
@@ -563,7 +564,7 @@ test("unsubscribes connection on bridge when calling returned function", () => {
   const adapter1 = createTestAdapter();
   const adapter2 = createTestAdapter();
 
-  const unsubscribe = createRPCBridge(adapter1, adapter2);
+  const unsubscribe = createMessageBridge(adapter1, adapter2);
 
   adapter1.simulateRPCMessage({
     id: "abc",

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -3,7 +3,6 @@ import type {
   MessageFormat,
 } from "./messages";
 import { MessageType, isEventMessage } from "./messages";
-import type { NoInfer } from "../types";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
 import { createId } from "../utils/createId";
@@ -16,10 +15,6 @@ export interface Actor<Messages extends MessageFormat> {
       : never
   ) => () => void;
   send: (message: Messages) => void;
-  forward: <TName extends Messages["type"]>(
-    name: TName,
-    actor: Actor<Extract<Messages, { type: NoInfer<TName> }>>
-  ) => () => void;
 }
 
 export function createActor<
@@ -96,8 +91,6 @@ export function createActor<
         message,
       });
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    forward: (name, actor) => on(name, actor.send as unknown as any),
   };
 }
 

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -119,7 +119,7 @@ export type DevtoolsRPCMessage = {
   getCache(clientId: string): JSONObject;
 };
 
-function isDevtoolsMessage<Message extends Record<string, unknown>>(
+export function isDevtoolsMessage<Message extends Record<string, unknown>>(
   message: unknown
 ): message is ApolloClientDevtoolsMessage<Message> {
   return (

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -142,10 +142,6 @@ export function isRPCResponseMessage(
   return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
 }
 
-export function isRPCMessage(message: unknown): message is RPCMessage {
-  return isRPCRequestMessage(message) || isRPCResponseMessage(message);
-}
-
 export function isEventMessage<Message extends Record<string, unknown>>(
   message: unknown
 ): message is ApolloClientDevtoolsEventMessage<Message> {

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -3,14 +3,9 @@ import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type {
-  RPCMessage,
-  RPCRequestMessage,
-  RPCResponseMessage,
-} from "./messages";
+import type { RPCRequestMessage, RPCResponseMessage } from "./messages";
 import {
   MessageType,
-  isRPCMessage,
   isRPCRequestMessage,
   isRPCResponseMessage,
 } from "./messages";
@@ -142,27 +137,5 @@ export function createRpcHandler<Messages extends MessageCollection>(
         stopListening();
       }
     };
-  };
-}
-
-export function createRPCBridge(
-  adapter1: MessageAdapter<RPCMessage>,
-  adapter2: MessageAdapter<RPCMessage>
-) {
-  const removeListener1 = adapter1.addListener((message) => {
-    if (isRPCMessage(message)) {
-      adapter2.postMessage(message);
-    }
-  });
-
-  const removeListener2 = adapter2.addListener((message) => {
-    if (isRPCMessage(message)) {
-      adapter1.postMessage(message);
-    }
-  });
-
-  return () => {
-    removeListener1();
-    removeListener2();
   };
 }

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -1,12 +1,10 @@
 // This script is injected into each tab.
 import browser from "webextension-polyfill";
-import type { ClientMessage } from "../messages";
-import { createActor, createWindowActor } from "../actor";
 import {
+  createMessageBridge,
   createPortMessageAdapter,
   createWindowMessageAdapter,
 } from "../messageAdapters";
-import { createRPCBridge } from "../rpc";
 
 declare const __IS_FIREFOX__: boolean;
 
@@ -14,17 +12,7 @@ const portAdapter = createPortMessageAdapter(() =>
   browser.runtime.connect({ name: "tab" })
 );
 
-const tab = createWindowActor<ClientMessage>(window);
-const devtools = createActor<ClientMessage>(portAdapter);
-
-createRPCBridge(portAdapter, createWindowMessageAdapter(window));
-
-devtools.forward("explorerSubscriptionTermination", tab);
-devtools.forward("explorerRequest", tab);
-
-tab.forward("registerClient", devtools);
-tab.forward("clientTerminated", devtools);
-tab.forward("explorerResponse", devtools);
+createMessageBridge(portAdapter, createWindowMessageAdapter(window));
 
 // We run the hook.js script on the page as a content script in Manifest v3
 // extensions (chrome for now). We do this using execution world MAIN.


### PR DESCRIPTION
Currently messages sent through the `actor` have extra steps needed to ensure the message makes it safely between the `hook` and the devtools app. Adding a new message requires adding the message type to the `messages` file, then remembering to add `forward` calls in both the `tab.ts` and `devtools.ts` files in order for the message to relay between the different message adapters.

This PR aims to simplify this by creating a unified message bridge that handles forwarding Apollo Client Devtools messages between any two actors in any direction. This is a replacement for the rpc message bridge that existed but only handled rpc messages. This change means that adding support for a new message can be done in a single place by editing the message types to propagate everywhere.