### PR TITLE
Unify and simplify actor and RPC message types

### DIFF
--- a/src/application/hooks/useActorEvent.ts
+++ b/src/application/hooks/useActorEvent.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useLayoutEffect, useRef } from "react";
-import type { EventMessage } from "../../extension/messages";
 import { getPanelActor } from "../../extension/devtools/panelActor";
+import type { EventMessage } from "../../extension/actor";
 
 export function useActorEvent<TName extends EventMessage["type"]>(
   name: TName,

--- a/src/application/hooks/useActorEvent.ts
+++ b/src/application/hooks/useActorEvent.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useLayoutEffect, useRef } from "react";
-import type { PanelMessage } from "../../extension/messages";
+import type { EventMessage } from "../../extension/messages";
 import { getPanelActor } from "../../extension/devtools/panelActor";
 
-export function useActorEvent<TName extends PanelMessage["type"]>(
+export function useActorEvent<TName extends EventMessage["type"]>(
   name: TName,
-  callback: Extract<PanelMessage, { type: TName }> extends infer Message
+  callback: Extract<EventMessage, { type: TName }> extends infer Message
     ? (message: Message) => void
     : never
 ) {

--- a/src/application/hooks/useActorEvent.ts
+++ b/src/application/hooks/useActorEvent.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { getPanelActor } from "../../extension/devtools/panelActor";
-import type { EventMessage } from "../../extension/actor";
+import type { ActorMessage } from "../../extension/actor";
 
-export function useActorEvent<TName extends EventMessage["type"]>(
+export function useActorEvent<TName extends ActorMessage["type"]>(
   name: TName,
-  callback: Extract<EventMessage, { type: TName }> extends infer Message
+  callback: Extract<ActorMessage, { type: TName }> extends infer Message
     ? (message: Message) => void
     : never
 ) {

--- a/src/application/schema.ts
+++ b/src/application/schema.ts
@@ -1,4 +1,3 @@
-import type { DevtoolsRPCMessage } from "../extension/messages";
 import type { RpcClient } from "../extension/rpc";
 import typeDefs from "./localSchema.graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
@@ -6,16 +5,14 @@ import type { Resolvers } from "./types/resolvers";
 import { getOperationName } from "@apollo/client/utilities";
 import { print } from "graphql";
 
-export function createSchemaWithRpcClient(
-  rpcClient: RpcClient<DevtoolsRPCMessage>
-) {
+export function createSchemaWithRpcClient(rpcClient: RpcClient) {
   return makeExecutableSchema({
     typeDefs,
     resolvers: createResolvers(rpcClient),
   });
 }
 
-function createResolvers(client: RpcClient<DevtoolsRPCMessage>): Resolvers {
+function createResolvers(client: RpcClient): Resolvers {
   const rpcClient = client.withTimeout(3000);
 
   return {

--- a/src/extension/__tests__/actor.test.ts
+++ b/src/extension/__tests__/actor.test.ts
@@ -1,7 +1,7 @@
 import { createActor } from "../actor";
 import { MessageType } from "../messages";
 
-function createTestAdapter<Messages = unknown>() {
+function createTestAdapter() {
   let listener: ((message: unknown) => void) | null;
   const removeListener = jest.fn(() => {
     listener = null;
@@ -12,7 +12,7 @@ function createTestAdapter<Messages = unknown>() {
     simulatePlainMessage: (message: unknown) => {
       listener?.(message);
     },
-    simulateDevtoolsMessage: (message: Messages) => {
+    simulateDevtoolsMessage: (message: Record<string, unknown>) => {
       listener?.({
         source: "apollo-client-devtools",
         type: MessageType.Event,
@@ -29,70 +29,65 @@ function createTestAdapter<Messages = unknown>() {
 }
 
 test("sends messages to specified adapter in devtools message format", () => {
-  type Message = { type: "test"; payload: string };
-
   const adapter = createTestAdapter();
-  const actor = createActor<Message>(adapter);
+  const actor = createActor(adapter);
 
-  actor.send({ type: "test", payload: "Hello" });
+  actor.send({ type: "clientTerminated", clientId: "1" });
 
   expect(adapter.postMessage).toHaveBeenCalledWith({
     id: expect.any(String),
     source: "apollo-client-devtools",
     type: MessageType.Event,
     message: {
-      type: "test",
-      payload: "Hello",
+      type: "clientTerminated",
+      clientId: "1",
     },
   });
 });
 
 test("calls message callback when subscribing to a message", () => {
-  type Message = { type: "connect"; payload: string } | { type: "disconnect" };
-
-  const adapter = createTestAdapter<Message>();
-  const actor = createActor<Message>(adapter);
+  const adapter = createTestAdapter();
+  const actor = createActor(adapter);
 
   const handleConnect = jest.fn();
   const handleDisconnect = jest.fn();
 
-  actor.on("connect", handleConnect);
-  actor.on("disconnect", handleDisconnect);
+  actor.on("initializePanel", handleConnect);
+  actor.on("clientTerminated", handleDisconnect);
 
-  adapter.simulateDevtoolsMessage({
-    type: "connect",
-    payload: "Connected!",
-  });
+  adapter.simulateDevtoolsMessage({ type: "initializePanel" });
 
   expect(handleConnect).toHaveBeenCalledTimes(1);
-  expect(handleConnect).toHaveBeenCalledWith({
-    type: "connect",
-    payload: "Connected!",
-  });
+  expect(handleConnect).toHaveBeenCalledWith({ type: "initializePanel" });
   expect(handleDisconnect).not.toHaveBeenCalled();
 
-  adapter.simulateDevtoolsMessage({ type: "disconnect" });
-  adapter.simulateDevtoolsMessage({ type: "disconnect" });
+  adapter.simulateDevtoolsMessage({ type: "clientTerminated", clientId: "1" });
+  adapter.simulateDevtoolsMessage({ type: "clientTerminated", clientId: "2" });
 
   expect(handleDisconnect).toHaveBeenCalledTimes(2);
-  expect(handleDisconnect).toHaveBeenCalledWith({ type: "disconnect" });
+  expect(handleDisconnect).toHaveBeenCalledWith({
+    type: "clientTerminated",
+    clientId: "1",
+  });
+  expect(handleDisconnect).toHaveBeenCalledWith({
+    type: "clientTerminated",
+    clientId: "2",
+  });
 });
 
 test("calls all listeners for the same message", () => {
-  type Message = { type: "test" };
-
-  const adapter = createTestAdapter<Message>();
-  const actor = createActor<Message>(adapter);
+  const adapter = createTestAdapter();
+  const actor = createActor(adapter);
 
   const handleMessage = jest.fn();
   const handleMessage2 = jest.fn();
   const handleMessage3 = jest.fn();
 
-  actor.on("test", handleMessage);
-  actor.on("test", handleMessage2);
-  actor.on("test", handleMessage3);
+  actor.on("initializePanel", handleMessage);
+  actor.on("initializePanel", handleMessage2);
+  actor.on("initializePanel", handleMessage3);
 
-  adapter.simulateDevtoolsMessage({ type: "test" });
+  adapter.simulateDevtoolsMessage({ type: "initializePanel" });
 
   expect(handleMessage).toHaveBeenCalledTimes(1);
   expect(handleMessage2).toHaveBeenCalledTimes(1);
@@ -100,14 +95,13 @@ test("calls all listeners for the same message", () => {
 });
 
 test("ignores messages that don't originate from devtools", () => {
-  type Message = { type: "test" };
   const adapter = createTestAdapter();
-  const actor = createActor<Message>(adapter);
+  const actor = createActor(adapter);
 
   const handleMessage = jest.fn();
-  actor.on("test", handleMessage);
+  actor.on("initializePanel", handleMessage);
 
-  adapter.simulatePlainMessage({ type: "test" });
+  adapter.simulatePlainMessage({ type: "initializePanel" });
 
   expect(handleMessage).not.toHaveBeenCalled();
 });
@@ -115,17 +109,16 @@ test("ignores messages that don't originate from devtools", () => {
 test.each([MessageType.RPCRequest, MessageType.RPCResponse])(
   "ignores messages that are %s messages",
   (messageType) => {
-    type Message = { type: "test" };
     const adapter = createTestAdapter();
-    const actor = createActor<Message>(adapter);
+    const actor = createActor(adapter);
 
     const handleMessage = jest.fn();
-    actor.on("test", handleMessage);
+    actor.on("initializePanel", handleMessage);
 
     adapter.simulatePlainMessage({
       source: "apollo-client-devtools",
       type: messageType,
-      message: { type: "test" },
+      message: { type: "initializePanel" },
     });
 
     expect(handleMessage).not.toHaveBeenCalled();
@@ -133,67 +126,57 @@ test.each([MessageType.RPCRequest, MessageType.RPCResponse])(
 );
 
 test("does not add listener to adapter until first subscribed actor listener", () => {
-  type Message = { type: "test" };
-
   const adapter = createTestAdapter();
-  const actor = createActor<Message>(adapter);
+  const actor = createActor(adapter);
 
   expect(adapter.addListener).not.toHaveBeenCalled();
 
-  actor.send({ type: "test" });
+  actor.send({ type: "initializePanel" });
   expect(adapter.addListener).not.toHaveBeenCalled();
 
-  actor.on("test", () => {});
+  actor.on("initializePanel", () => {});
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 });
 
 test("adds a single listener to adapter regardless of subscribed actor listeners", () => {
-  type Message =
-    | { type: "test" }
-    | { type: "greet" }
-    | { type: "connect" }
-    | { type: "disconnect" };
-
   const adapter = createTestAdapter();
-  const actor = createActor<Message>(adapter);
+  const actor = createActor(adapter);
 
-  actor.on("test", () => {});
-  actor.on("greet", () => {});
-  actor.on("disconnect", () => {});
-  actor.on("connect", () => {});
+  actor.on("initializePanel", () => {});
+  actor.on("registerClient", () => {});
+  actor.on("clientTerminated", () => {});
+  actor.on("panelShown", () => {});
 
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 });
 
 test("can unsubscribe from a message by calling the returned function", () => {
-  type Message = { type: "test" };
-  const adapter = createTestAdapter<Message>();
-  const actor = createActor<Message>(adapter);
+  const adapter = createTestAdapter();
+  const actor = createActor(adapter);
 
   const handleMessage = jest.fn();
-  const unsubscribe = actor.on("test", handleMessage);
+  const unsubscribe = actor.on("initializePanel", handleMessage);
 
-  adapter.simulateDevtoolsMessage({ type: "test" });
+  adapter.simulateDevtoolsMessage({ type: "initializePanel" });
 
   expect(handleMessage).toHaveBeenCalledTimes(1);
 
   handleMessage.mockClear();
   unsubscribe();
 
-  adapter.simulateDevtoolsMessage({ type: "test" });
+  adapter.simulateDevtoolsMessage({ type: "initializePanel" });
 
   expect(handleMessage).not.toHaveBeenCalled();
 });
 
 test("removes listener on adapter when unsubscribing from last actor listener", () => {
-  type Message = { type: "connect" } | { type: "disconnect" };
-  const adapter = createTestAdapter<Message>();
-  const actor = createActor<Message>(adapter);
+  const adapter = createTestAdapter();
+  const actor = createActor(adapter);
 
   const handleConnect = jest.fn();
   const handleDisconnect = jest.fn();
-  const unsubscribeConnect = actor.on("connect", handleConnect);
-  const unsubscribeDisconnect = actor.on("connect", handleDisconnect);
+  const unsubscribeConnect = actor.on("initializePanel", handleConnect);
+  const unsubscribeDisconnect = actor.on("clientTerminated", handleDisconnect);
 
   unsubscribeConnect();
 
@@ -205,12 +188,11 @@ test("removes listener on adapter when unsubscribing from last actor listener", 
 });
 
 test("re-adds listener on adapter when subscribing actor listener after disconnecting", () => {
-  type Message = { type: "connect" };
-  const adapter = createTestAdapter<Message>();
-  const actor = createActor<Message>(adapter);
+  const adapter = createTestAdapter();
+  const actor = createActor(adapter);
 
   const handleConnect = jest.fn();
-  const unsubscribeConnect = actor.on("connect", handleConnect);
+  const unsubscribeConnect = actor.on("initializePanel", handleConnect);
 
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 
@@ -219,6 +201,6 @@ test("re-adds listener on adapter when subscribing actor listener after disconne
 
   adapter.addListener.mockClear();
 
-  actor.on("connect", handleConnect);
+  actor.on("initializePanel", handleConnect);
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 });

--- a/src/extension/__tests__/actor.test.ts
+++ b/src/extension/__tests__/actor.test.ts
@@ -15,7 +15,7 @@ function createTestAdapter() {
     simulateDevtoolsMessage: (message: Record<string, unknown>) => {
       listener?.({
         source: "apollo-client-devtools",
-        type: MessageType.Event,
+        type: MessageType.Actor,
         message,
       });
     },
@@ -37,7 +37,7 @@ test("sends messages to specified adapter in devtools message format", () => {
   expect(adapter.postMessage).toHaveBeenCalledWith({
     id: expect.any(String),
     source: "apollo-client-devtools",
-    type: MessageType.Event,
+    type: MessageType.Actor,
     message: {
       type: "clientTerminated",
       clientId: "1",

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -2,9 +2,11 @@ import type { ApolloClientInfo, DistributiveOmit } from "../../types";
 import { RPC_MESSAGE_TIMEOUT } from "../errorMessages";
 import type { MessageAdapter } from "../messageAdapters";
 import { createMessageBridge } from "../messageAdapters";
-import type { RPCMessage, RPCRequestMessage } from "../messages";
+import type { RPCRequestMessage, RPCResponseMessage } from "../messages";
 import { MessageType } from "../messages";
 import { createRpcClient, createRpcHandler } from "../rpc";
+
+type RPCMessage = RPCRequestMessage | RPCResponseMessage;
 
 interface TestAdapter extends MessageAdapter {
   mocks: { listeners: Set<(message: unknown) => void>; messages: unknown[] };

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -1,4 +1,4 @@
-import type { DistributiveOmit } from "../../types";
+import type { ApolloClientInfo, DistributiveOmit } from "../../types";
 import { RPC_MESSAGE_TIMEOUT } from "../errorMessages";
 import type { MessageAdapter } from "../messageAdapters";
 import { createMessageBridge } from "../messageAdapters";
@@ -6,7 +6,7 @@ import type { RPCMessage, RPCRequestMessage } from "../messages";
 import { MessageType } from "../messages";
 import { createRpcClient, createRpcHandler } from "../rpc";
 
-interface TestAdapter extends MessageAdapter<RPCMessage> {
+interface TestAdapter extends MessageAdapter {
   mocks: { listeners: Set<(message: unknown) => void>; messages: unknown[] };
   simulateMessage: (message: unknown) => void;
   simulateRPCMessage: (message: DistributiveOmit<RPCMessage, "source">) => void;
@@ -56,60 +56,61 @@ function createBridge(adapter1: TestAdapter, adapter2: TestAdapter) {
   adapter2.connect(adapter1);
 }
 
+function defaultGetClient(id: string) {
+  return {
+    id,
+    name: "Test",
+    version: "3.11.0",
+    queryCount: 0,
+    mutationCount: 0,
+  } satisfies ApolloClientInfo;
+}
+
 test("can send and receive rpc messages", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
   // Since these are sent over separate instances in the real world, we want to
   // simulate that as best as we can with separate adapters
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", (x, y) => x + y);
+  handle("getClient", defaultGetClient);
 
-  const result = await client.request("add", 1, 2);
+  const result = await client.request("getClient", "1");
 
-  expect(result).toBe(3);
+  expect(result).toEqual(defaultGetClient("1"));
 });
 
 test("resolves async handlers", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
   // Since these are sent over separate instances in the real world, we want to
   // simulate that as best as we can with separate adapters
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", (x, y) => {
-    return new Promise<number>((resolve) => {
+  handle("getClient", (id) => {
+    return new Promise<ApolloClientInfo>((resolve) => {
       setTimeout(() => {
-        resolve(x + y);
+        resolve(defaultGetClient(id));
       }, 10);
     });
   });
 
-  const result = await client.request("add", 1, 2);
+  const result = await client.request("getClient", "1");
 
-  expect(result).toBe(3);
+  expect(result).toEqual(defaultGetClient("1"));
 });
 
 test("does not mistakenly handle messages from different rpc calls", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
   const clientAdapter = createTestAdapter();
-  const client = createRpcClient<Message>(clientAdapter);
+  const client = createRpcClient(clientAdapter);
 
-  const promise = client.request("add", 1, 2);
+  const promise = client.request("getClient", "1");
 
   const { id } = clientAdapter.mocks.messages[0] as RPCRequestMessage;
 
@@ -117,77 +118,73 @@ test("does not mistakenly handle messages from different rpc calls", async () =>
     id: "zef",
     type: MessageType.RPCResponse,
     sourceId: id + "zzz",
-    result: 4,
+    result: {
+      id: "2",
+      name: "Nope",
+      version: "3.7.0",
+      queryCount: 10,
+      mutationCount: 20,
+    },
   });
 
   clientAdapter.simulateRPCMessage({
     type: MessageType.RPCResponse,
     id: "abcdefg",
     sourceId: id,
-    result: 3,
+    result: defaultGetClient("1"),
   });
 
-  await expect(promise).resolves.toBe(3);
+  await expect(promise).resolves.toEqual(defaultGetClient("1"));
 });
 
 test("rejects when handler throws error", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
   // Since these are sent over separate instances in the real world, we want to
   // simulate that as best as we can with separate adapters
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", () => {
-    throw new Error("Could not add");
+  handle("getClient", () => {
+    throw new Error("Could not get client");
   });
 
-  await expect(client.request("add", 1, 2)).rejects.toEqual(
-    new Error("Could not add")
+  await expect(client.request("getClient", "1")).rejects.toEqual(
+    new Error("Could not get client")
   );
 });
 
 test("rejects when async handler rejects", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
   // Since these are sent over separate instances in the real world, we want to
   // simulate that as best as we can with separate adapters
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", () => Promise.reject(new Error("Could not add")));
+  handle("getClient", () => Promise.reject(new Error("Could not get client")));
 
-  await expect(client.request("add", 1, 2)).rejects.toEqual(
-    new Error("Could not add")
+  await expect(client.request("getClient", "1")).rejects.toEqual(
+    new Error("Could not get client")
   );
 });
 
 test("maintains error name", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
-
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", () => Promise.reject(new SyntaxError()));
+  handle("getClient", () => Promise.reject(new SyntaxError()));
 
   try {
-    await client.request("add", 1, 2);
+    await client.request("getClient", "1");
     throw new Error("Should not reach");
   } catch (e) {
     expect(e).toBeInstanceOf(SyntaxError);
@@ -196,94 +193,80 @@ test("maintains error name", async () => {
 });
 
 test("can handle multiple rpc messages", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-    // while we're at it, let's have this one return a Promise in the definition
-    // it should not matter for the implementation
-    shout(text: string): Promise<string>;
-  };
-
   const handlerAdapter = createTestAdapter();
   const clientAdapter = createTestAdapter();
   createBridge(clientAdapter, handlerAdapter);
 
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
+  const client = createRpcClient(clientAdapter);
+  const handle = createRpcHandler(handlerAdapter);
 
-  handle("add", (x, y) => x + y);
-  handle("shout", (text) => Promise.resolve(text.toUpperCase()));
+  handle("getClient", defaultGetClient);
+  handle("getQueries", () => Promise.resolve([]));
 
-  const result = await client.request("add", 1, 2);
-  const uppercase = await client.request("shout", "hello");
+  const result = await client.request("getClient", "1");
+  const queries = await client.request("getQueries", "1");
 
-  expect(result).toBe(3);
-  expect(uppercase).toBe("HELLO");
+  expect(result).toEqual(defaultGetClient("1"));
+  expect(queries).toEqual([]);
 });
 
 test("only allows one handler per type", async () => {
-  type Message = {
-    add({ x, y }: { x: number; y: number }): number;
-  };
+  const handle = createRpcHandler(createTestAdapter());
 
-  const handle = createRpcHandler<Message>(createTestAdapter());
-
-  handle("add", ({ x, y }) => x + y);
+  handle("getClient", defaultGetClient);
 
   expect(() => {
-    handle("add", ({ x, y }) => x - y);
+    handle("getClient", defaultGetClient);
   }).toThrow(new Error("Only one rpc handler can be registered per type"));
 });
 
-test("can handle any parameter format", async () => {
-  type Message = {
-    add(x: number, y: number): number;
-    shout(text: string): string;
-    join(strings: string[], delimeter: string): string;
-    getFullName(user: { firstName: string; lastName: string }): string;
-    getStoredValues(): number[];
-  };
-
-  const handlerAdapter = createTestAdapter();
-  const clientAdapter = createTestAdapter();
-  createBridge(clientAdapter, handlerAdapter);
-
-  const client = createRpcClient<Message>(clientAdapter);
-  const handle = createRpcHandler<Message>(handlerAdapter);
-
-  handle("add", (x, y) => x + y);
-  handle("shout", (text) => text.toUpperCase());
-  handle("join", (strings, delimeter) => strings.join(delimeter));
-  handle("getFullName", (user) => user.firstName + " " + user.lastName);
-  handle("getStoredValues", () => [1, 2, 3]);
-
-  const result = await client.request("add", 1, 2);
-  const uppercase = await client.request("shout", "hello");
-  const joined = await client.request("join", ["a", "b", "c"], ",");
-  const fullName = await client.request("getFullName", {
-    firstName: "John",
-    lastName: "Doe",
-  });
-  const storedValues = await client.request("getStoredValues");
-
-  expect(result).toBe(3);
-  expect(uppercase).toBe("HELLO");
-  expect(joined).toEqual("a,b,c");
-  expect(fullName).toEqual("John Doe");
-  expect(storedValues).toEqual([1, 2, 3]);
+// Would love to contineu to test this, but our current messages don't allow for this.
+test.skip("can handle any parameter format", async () => {
+  // type Message = {
+  //   add(x: number, y: number): number;
+  //   shout(text: string): string;
+  //   join(strings: string[], delimeter: string): string;
+  //   getFullName(user: { firstName: string; lastName: string }): string;
+  //   getStoredValues(): number[];
+  // };
+  //
+  // const handlerAdapter = createTestAdapter();
+  // const clientAdapter = createTestAdapter();
+  // createBridge(clientAdapter, handlerAdapter);
+  //
+  // const client = createRpcClient<Message>(clientAdapter);
+  // const handle = createRpcHandler<Message>(handlerAdapter);
+  //
+  // handle("add", (x, y) => x + y);
+  // handle("shout", (text) => text.toUpperCase());
+  // handle("join", (strings, delimeter) => strings.join(delimeter));
+  // handle("getFullName", (user) => user.firstName + " " + user.lastName);
+  // handle("getStoredValues", () => [1, 2, 3]);
+  //
+  // const result = await client.request("add", 1, 2);
+  // const uppercase = await client.request("shout", "hello");
+  // const joined = await client.request("join", ["a", "b", "c"], ",");
+  // const fullName = await client.request("getFullName", {
+  //   firstName: "John",
+  //   lastName: "Doe",
+  // });
+  // const storedValues = await client.request("getStoredValues");
+  //
+  // expect(result).toBe(3);
+  // expect(uppercase).toBe("HELLO");
+  // expect(joined).toEqual("a,b,c");
+  // expect(fullName).toEqual("John Doe");
+  // expect(storedValues).toEqual([1, 2, 3]);
 });
 
 test("ignores messages that don't originate from devtools", () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
   const callback = jest.fn();
-  handle("add", callback);
+  handle("getClient", callback);
 
-  adapter.simulateMessage({ type: "add", x: 1, y: 2 });
+  adapter.simulateMessage({ type: "getClient", clientId: "1" });
 
   expect(callback).not.toHaveBeenCalled();
 });
@@ -292,139 +275,108 @@ test("ignores messages that don't originate from devtools", () => {
 // actor message type collides with an rpc message type, we want to ignore the
 // actor message type.
 test("ignores messages that aren't rpc messages", () => {
-  type Message = {
-    add({ x, y }: { x: number; y: number }): number;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
-  const callback = jest.fn();
-  handle("add", callback);
+  const getClient = jest.fn();
+  handle("getClient", getClient);
 
   adapter.simulateMessage({
     source: "apollo-client-devtools",
     type: MessageType.Event,
-    payload: { type: "add", x: 1, y: 2 },
+    payload: { type: "getClient", clientId: "1" },
   });
 
-  expect(callback).not.toHaveBeenCalled();
+  expect(getClient).not.toHaveBeenCalled();
 });
 
 test("does not add listener to adapter until first subscribed handler", () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
   expect(adapter.addListener).not.toHaveBeenCalled();
 
-  handle("add", (x, y) => x + y);
+  handle("getClient", defaultGetClient);
 
   expect(adapter.addListener).toHaveBeenCalled();
 });
 
 test("adds a single listener regardless of active handlers", () => {
-  type Message = {
-    add(x: number, y: number): number;
-    subtract(x: number, y: number): number;
-    shout(text: string): string;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
   expect(adapter.addListener).not.toHaveBeenCalled();
 
-  handle("add", (x, y) => x + y);
-  handle("subtract", (x, y) => x - y);
-  handle("shout", (text) => text.toUpperCase());
+  handle("getClient", defaultGetClient);
+  handle("getQueries", () => []);
+  handle("getMutations", () => []);
 
   expect(adapter.addListener).toHaveBeenCalledTimes(1);
 });
 
 test("can unsubscribe from a handler by calling the returned function", () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
-  const add = jest.fn();
-  const unsubscribe = handle("add", add);
+  const getClient = jest.fn();
+  const unsubscribe = handle("getClient", getClient);
 
   adapter.simulateRPCMessage({
     id: "abc",
     type: MessageType.RPCRequest,
-    name: "add",
-    params: [{ x: 1, y: 2 }],
+    name: "getClient",
+    params: ["1"],
   });
 
-  expect(add).toHaveBeenCalledTimes(1);
+  expect(getClient).toHaveBeenCalledTimes(1);
 
-  add.mockClear();
+  getClient.mockClear();
   unsubscribe();
 
   adapter.simulateRPCMessage({
     id: "xyz",
     type: MessageType.RPCRequest,
-    name: "add",
-    params: [{ x: 1, y: 2 }],
+    name: "getClient",
+    params: ["2"],
   });
 
-  expect(add).not.toHaveBeenCalled();
+  expect(getClient).not.toHaveBeenCalled();
 });
 
 test("removes listener on adapter when unsubscribing from last handler", () => {
-  type Message = {
-    add(x: number, y: number): number;
-    shout({ text }: { text: string }): string;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
-  const unsubscribeAdd = handle("add", (x, y) => x + y);
-  const unsubscribeShout = handle("shout", ({ text }) => text.toUpperCase());
+  const unsubscribeGetClient = handle("getClient", defaultGetClient);
+  const unsubscribeGetQueries = handle("getQueries", () => []);
 
-  unsubscribeAdd();
+  unsubscribeGetClient();
   expect(adapter.mocks.listeners.size).toBe(1);
 
-  unsubscribeShout();
+  unsubscribeGetQueries();
   expect(adapter.mocks.listeners.size).toBe(0);
 });
 
 test("re-adds listener on adapter when subscribing after unsubscribing", () => {
-  type Message = {
-    add(x: number, y: number): number;
-  };
-
   const adapter = createTestAdapter();
-  const handle = createRpcHandler<Message>(adapter);
+  const handle = createRpcHandler(adapter);
 
-  const add = (x: number, y: number) => x + y;
-  const unsubscribe = handle("add", add);
+  const unsubscribe = handle("getClient", defaultGetClient);
 
   unsubscribe();
   expect(adapter.mocks.listeners.size).toBe(0);
 
-  handle("add", add);
+  handle("getClient", defaultGetClient);
   expect(adapter.mocks.listeners.size).toBe(1);
 });
 
 test("times out if no message received within default timeout", async () => {
   jest.useFakeTimers();
-  type Message = {
-    add(x: number, y: number): number;
-  };
 
   const adapter = createTestAdapter();
-  const client = createRpcClient<Message>(adapter);
+  const client = createRpcClient(adapter);
 
-  const promise = client.request("add", 1, 2);
+  const promise = client.request("getClient", "1");
 
   jest.advanceTimersByTime(30_000);
 
@@ -435,14 +387,11 @@ test("times out if no message received within default timeout", async () => {
 
 test("times out if no message received within configured timeout", async () => {
   jest.useFakeTimers();
-  type Message = {
-    add(x: number, y: number): number;
-  };
 
   const adapter = createTestAdapter();
-  const client = createRpcClient<Message>(adapter);
+  const client = createRpcClient(adapter);
 
-  const promise = client.withTimeout(1000).request("add", 1, 2);
+  const promise = client.withTimeout(1000).request("getClient", "1");
 
   jest.advanceTimersByTime(1000);
 
@@ -453,12 +402,9 @@ test("times out if no message received within configured timeout", async () => {
 
 test("resets timeout to default timeout after sending request", async () => {
   jest.useFakeTimers();
-  type Message = {
-    add(x: number, y: number): number;
-  };
 
   const adapter = createTestAdapter();
-  const client = createRpcClient<Message>(adapter);
+  const client = createRpcClient(adapter);
 
   const t1 = client.withTimeout(1000);
   const t2 = client.withTimeout(2000);
@@ -467,16 +413,16 @@ test("resets timeout to default timeout after sending request", async () => {
   expect(t1.timeout).toBe(1000);
   expect(t2.timeout).toBe(2000);
 
-  const finished = new Set<Promise<number>>();
+  const finished = new Set<Promise<ApolloClientInfo | null>>();
 
-  const promise1 = t1.request("add", 1, 2);
+  const promise1 = t1.request("getClient", "1");
   promise1
     .finally(() => finished.add(promise1))
     .catch(() => {
       /* prevent unhandled rejection warning */
     });
 
-  const promise2 = t2.request("add", 1, 2);
+  const promise2 = t2.request("getClient", "2");
   promise2
     .finally(() => finished.add(promise2))
     .catch(() => {
@@ -498,7 +444,7 @@ test("resets timeout to default timeout after sending request", async () => {
   expect(finished).toContain(promise2);
   await expect(promise2).rejects.toEqual(new Error(RPC_MESSAGE_TIMEOUT));
 
-  const promise3 = client.request("add", 1, 2);
+  const promise3 = client.request("getClient", "1");
   promise3
     .finally(() => finished.add(promise3))
     .catch(() => {

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -2,8 +2,8 @@ import type { ApolloClientInfo, DistributiveOmit } from "../../types";
 import { RPC_MESSAGE_TIMEOUT } from "../errorMessages";
 import type { MessageAdapter } from "../messageAdapters";
 import { createMessageBridge } from "../messageAdapters";
-import type { RPCRequestMessage, RPCResponseMessage } from "../messages";
 import { MessageType } from "../messages";
+import type { RPCRequestMessage, RPCResponseMessage } from "../rpc";
 import { createRpcClient, createRpcHandler } from "../rpc";
 
 type RPCMessage = RPCRequestMessage | RPCResponseMessage;

--- a/src/extension/__tests__/rpc.test.ts
+++ b/src/extension/__tests__/rpc.test.ts
@@ -283,7 +283,7 @@ test("ignores messages that aren't rpc messages", () => {
 
   adapter.simulateMessage({
     source: "apollo-client-devtools",
-    type: MessageType.Event,
+    type: MessageType.Actor,
     payload: { type: "getClient", clientId: "1" },
   });
 

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -18,7 +18,7 @@ export function createActor<
   Messages extends MessageFormat = {
     type: "Error: Pass <Messages> to `createActor<Messages>()`";
   },
->(adapter: MessageAdapter<Messages>): Actor<Messages> {
+>(adapter: MessageAdapter): Actor<Messages> {
   let removeListener: (() => void) | null = null;
   const messageListeners = new Map<
     Messages["type"],

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,4 +1,4 @@
-import { MessageType, isEventMessage } from "./messages";
+import { MessageType, isActorMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
 import { createId } from "../utils/createId";
@@ -44,7 +44,7 @@ export function createActor(adapter: MessageAdapter): Actor {
   >();
 
   function handleMessage(message: unknown) {
-    if (!isEventMessage(message)) {
+    if (!isActorMessage(message)) {
       return;
     }
 

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -6,7 +6,7 @@ import type { ApolloClientInfo, ExplorerResponse } from "../types";
 import type { DocumentNode, FetchPolicy } from "@apollo/client";
 import type { JSONObject } from "../application/types/json";
 
-export type EventMessage =
+export type ActorMessage =
   | { type: "registerClient"; payload: ApolloClientInfo }
   | { type: "clientTerminated"; clientId: string }
   | {
@@ -27,20 +27,20 @@ export type EventMessage =
   | { type: "panelShown" };
 
 export interface Actor {
-  on: <TName extends EventMessage["type"]>(
+  on: <TName extends ActorMessage["type"]>(
     name: TName,
-    callback: Extract<EventMessage, { type: TName }> extends infer Message
+    callback: Extract<ActorMessage, { type: TName }> extends infer Message
       ? (message: Message) => void
       : never
   ) => () => void;
-  send: (message: EventMessage) => void;
+  send: (message: ActorMessage) => void;
 }
 
 export function createActor(adapter: MessageAdapter): Actor {
   let removeListener: (() => void) | null = null;
   const messageListeners = new Map<
-    EventMessage["type"],
-    Set<(message: EventMessage) => void>
+    ActorMessage["type"],
+    Set<(message: ActorMessage) => void>
   >();
 
   function handleMessage(message: unknown) {
@@ -77,7 +77,7 @@ export function createActor(adapter: MessageAdapter): Actor {
       listeners = new Set();
       messageListeners.set(
         name,
-        listeners as Set<(message: EventMessage) => void>
+        listeners as Set<(message: ActorMessage) => void>
       );
     }
 

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,4 +1,3 @@
-import type { ApolloClientDevtoolsActorMessage } from "./messages";
 import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
@@ -26,6 +25,13 @@ export type ActorMessage =
   | { type: "initializePanel" }
   | { type: "panelHidden" }
   | { type: "panelShown" };
+
+export type ApolloClientDevtoolsActorMessage = {
+  id: string;
+  source: "apollo-client-devtools";
+  type: MessageType.Event;
+  message: ActorMessage;
+};
 
 export interface Actor {
   on: <TName extends ActorMessage["type"]>(

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,7 +1,4 @@
-import type {
-  ApolloClientDevtoolsEventMessage,
-  MessageFormat,
-} from "./messages";
+import type { MessageFormat } from "./messages";
 import { MessageType, isEventMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
@@ -21,9 +18,7 @@ export function createActor<
   Messages extends MessageFormat = {
     type: "Error: Pass <Messages> to `createActor<Messages>()`";
   },
->(
-  adapter: MessageAdapter<ApolloClientDevtoolsEventMessage<Messages>>
-): Actor<Messages> {
+>(adapter: MessageAdapter<Messages>): Actor<Messages> {
   let removeListener: (() => void) | null = null;
   const messageListeners = new Map<
     Messages["type"],

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,8 +1,30 @@
-import type { EventMessage } from "./messages";
 import { MessageType, isEventMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
 import { createId } from "../utils/createId";
+import type { ApolloClientInfo, ExplorerResponse } from "../types";
+import type { DocumentNode, FetchPolicy } from "@apollo/client";
+import type { JSONObject } from "../application/types/json";
+
+export type EventMessage =
+  | { type: "registerClient"; payload: ApolloClientInfo }
+  | { type: "clientTerminated"; clientId: string }
+  | {
+      type: "explorerRequest";
+      payload: {
+        clientId: string;
+        operation: DocumentNode;
+        operationName: string | undefined;
+        variables: JSONObject | undefined;
+        fetchPolicy: FetchPolicy;
+      };
+    }
+  | { type: "explorerResponse"; payload: ExplorerResponse }
+  | { type: "explorerSubscriptionTermination" }
+  | { type: "pageNavigated" }
+  | { type: "initializePanel" }
+  | { type: "panelHidden" }
+  | { type: "panelShown" };
 
 export interface Actor {
   on: <TName extends EventMessage["type"]>(

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -82,10 +82,7 @@ export function createActor(adapter: MessageAdapter): Actor {
 
     if (!listeners) {
       listeners = new Set();
-      messageListeners.set(
-        name,
-        listeners as Set<(message: ActorMessage) => void>
-      );
+      messageListeners.set(name, listeners);
     }
 
     listeners.add(callback);

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,4 +1,5 @@
-import { MessageType, isActorMessage } from "./messages";
+import type { ApolloClientDevtoolsEventMessage } from "./messages";
+import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
 import { createId } from "../utils/createId";
@@ -112,4 +113,10 @@ export function createActor(adapter: MessageAdapter): Actor {
 
 export function createWindowActor(window: Window) {
   return createActor(createWindowMessageAdapter(window));
+}
+
+function isActorMessage(
+  message: unknown
+): message is ApolloClientDevtoolsEventMessage {
+  return isDevtoolsMessage(message) && message.type === MessageType.Event;
 }

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -1,4 +1,4 @@
-import type { ApolloClientDevtoolsEventMessage } from "./messages";
+import type { ApolloClientDevtoolsActorMessage } from "./messages";
 import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MessageAdapter } from "./messageAdapters";
 import { createWindowMessageAdapter } from "./messageAdapters";
@@ -117,6 +117,6 @@ export function createWindowActor(window: Window) {
 
 function isActorMessage(
   message: unknown
-): message is ApolloClientDevtoolsEventMessage {
+): message is ApolloClientDevtoolsActorMessage {
   return isDevtoolsMessage(message) && message.type === MessageType.Event;
 }

--- a/src/extension/actor.ts
+++ b/src/extension/actor.ts
@@ -29,7 +29,7 @@ export type ActorMessage =
 export type ApolloClientDevtoolsActorMessage = {
   id: string;
   source: "apollo-client-devtools";
-  type: MessageType.Event;
+  type: MessageType.Actor;
   message: ActorMessage;
 };
 
@@ -110,7 +110,7 @@ export function createActor(adapter: MessageAdapter): Actor {
       adapter.postMessage({
         id: createId(),
         source: "apollo-client-devtools",
-        type: MessageType.Event,
+        type: MessageType.Actor,
         message,
       });
     },
@@ -124,5 +124,5 @@ export function createWindowActor(window: Window) {
 function isActorMessage(
   message: unknown
 ): message is ApolloClientDevtoolsActorMessage {
-  return isDevtoolsMessage(message) && message.type === MessageType.Event;
+  return isDevtoolsMessage(message) && message.type === MessageType.Actor;
 }

--- a/src/extension/background/errorcodes.ts
+++ b/src/extension/background/errorcodes.ts
@@ -10,9 +10,8 @@ export type ErrorCodesHandler = {
 };
 browser.runtime.onConnect.addListener((port) => {
   if (port.name === "tab") {
-    const handleRpc = createRpcHandler<ErrorCodesHandler>(
-      createPortMessageAdapter(() => port)
-    );
+    const handleRpc = createRpcHandler(createPortMessageAdapter(() => port));
+
     handleRpc("getErrorCodes", (version) => {
       if (version in allErrorCodes.byVersion) {
         return restoreErrorCodes(allErrorCodes, version);

--- a/src/extension/background/errorcodes.ts
+++ b/src/extension/background/errorcodes.ts
@@ -1,13 +1,9 @@
 import browser from "webextension-polyfill";
 import { createRpcHandler } from "../rpc";
 import { createPortMessageAdapter } from "../messageAdapters";
-import type { ErrorCodes } from "@apollo/client/invariantErrorCodes.js";
 import allErrorCodes from "../../../all-clients/errorcodes.json";
 import { restoreErrorCodes } from "../../../all-clients/restore-errorcodes.mjs";
 
-export type ErrorCodesHandler = {
-  getErrorCodes(version: string): Promise<ErrorCodes | undefined>;
-};
 browser.runtime.onConnect.addListener((port) => {
   if (port.name === "tab") {
     const handleRpc = createRpcHandler(createPortMessageAdapter(() => port));

--- a/src/extension/devtools/__mocks__/panelRpcClient.ts
+++ b/src/extension/devtools/__mocks__/panelRpcClient.ts
@@ -1,9 +1,8 @@
 import { createTestAdapter } from "../../../testUtils/testMessageAdapter";
-import type { DevtoolsRPCMessage } from "../../messages";
 import { createRpcClient } from "../../rpc";
 
 const adapter = createTestAdapter();
-const rpcClient = createRpcClient<DevtoolsRPCMessage>(adapter);
+const rpcClient = createRpcClient(adapter);
 
 export type GetRpcClientMock = typeof getRpcClient;
 

--- a/src/extension/devtools/devtools.ts
+++ b/src/extension/devtools/devtools.ts
@@ -1,6 +1,5 @@
 import browser from "webextension-polyfill";
 import type { Actor } from "../actor";
-import type { PanelMessage } from "../messages";
 import { getPanelActor } from "./panelActor";
 import {
   createMessageBridge,
@@ -15,7 +14,7 @@ const portAdapter = createPortMessageAdapter(() =>
 );
 
 let connectedToPanel = false;
-let panelWindow: Actor<PanelMessage>;
+let panelWindow: Actor;
 
 async function createDevtoolsPanel() {
   const panel = await browser.devtools.panels.create(

--- a/src/extension/devtools/panelActor.ts
+++ b/src/extension/devtools/panelActor.ts
@@ -1,9 +1,8 @@
 import type { Actor } from "../actor";
 import { createWindowActor } from "../actor";
-import type { PanelMessage } from "../messages";
 
-let panelActor: Actor<PanelMessage> | null = null;
+let panelActor: Actor | null = null;
 
 export const getPanelActor = (window: Window) => {
-  return (panelActor ||= createWindowActor<PanelMessage>(window));
+  return (panelActor ||= createWindowActor(window));
 };

--- a/src/extension/devtools/panelRpcClient.ts
+++ b/src/extension/devtools/panelRpcClient.ts
@@ -1,11 +1,8 @@
 import { createWindowMessageAdapter } from "../messageAdapters";
-import type { DevtoolsRPCMessage } from "../messages";
 import { createRpcClient, type RpcClient } from "../rpc";
 
-let rpcClient: RpcClient<DevtoolsRPCMessage> | null = null;
+let rpcClient: RpcClient | null = null;
 
 export function getRpcClient() {
-  return (rpcClient ||= createRpcClient<DevtoolsRPCMessage>(
-    createWindowMessageAdapter(window)
-  ));
+  return (rpcClient ||= createRpcClient(createWindowMessageAdapter(window)));
 }

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -1,20 +1,17 @@
 import type browser from "webextension-polyfill";
 import { isDevtoolsMessage } from "./messages";
 import type { ApolloClientDevtoolsMessage } from "./messages";
-import type { SafeAny } from "../types";
 
-export interface MessageAdapter<
-  PostMessageFormat extends Record<string, unknown>,
-> {
+export interface MessageAdapter {
   addListener: (listener: (message: unknown) => void) => () => void;
   postMessage: (
-    message: ApolloClientDevtoolsMessage<PostMessageFormat>
+    message: ApolloClientDevtoolsMessage<Record<string, unknown>>
   ) => void;
 }
 
-export function createPortMessageAdapter<
-  PostMessageFormat extends Record<string, unknown> = Record<string, unknown>,
->(createPort: () => browser.Runtime.Port): MessageAdapter<PostMessageFormat> {
+export function createPortMessageAdapter(
+  createPort: () => browser.Runtime.Port
+): MessageAdapter {
   let port = createPort();
   const listeners = new Set<(message: unknown) => void>();
 
@@ -52,9 +49,7 @@ export function createPortMessageAdapter<
   };
 }
 
-export function createWindowMessageAdapter<
-  PostMessageFormat extends Record<string, unknown> = Record<string, unknown>,
->(window: Window): MessageAdapter<PostMessageFormat> {
+export function createWindowMessageAdapter(window: Window): MessageAdapter {
   const sentMessageIds = new Set<string>();
 
   return {
@@ -88,8 +83,8 @@ export function createWindowMessageAdapter<
 }
 
 export function createMessageBridge(
-  adapter1: MessageAdapter<SafeAny>,
-  adapter2: MessageAdapter<SafeAny>
+  adapter1: MessageAdapter,
+  adapter2: MessageAdapter
 ) {
   const removeListener1 = adapter1.addListener((message) => {
     if (isDevtoolsMessage(message)) {

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -4,19 +4,17 @@ import type { ApolloClientDevtoolsMessage } from "./messages";
 import type { SafeAny } from "../types";
 
 export interface MessageAdapter<
-  PostMessageFormat extends ApolloClientDevtoolsMessage<
-    Record<string, unknown>
-  >,
+  PostMessageFormat extends Record<string, unknown>,
 > {
   addListener: (listener: (message: unknown) => void) => () => void;
-  postMessage: (message: PostMessageFormat) => void;
+  postMessage: (
+    message: ApolloClientDevtoolsMessage<PostMessageFormat>
+  ) => void;
 }
 
 export function createPortMessageAdapter<
   PostMessageFormat extends Record<string, unknown> = Record<string, unknown>,
->(
-  createPort: () => browser.Runtime.Port
-): MessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
+>(createPort: () => browser.Runtime.Port): MessageAdapter<PostMessageFormat> {
   let port = createPort();
   const listeners = new Set<(message: unknown) => void>();
 
@@ -56,9 +54,7 @@ export function createPortMessageAdapter<
 
 export function createWindowMessageAdapter<
   PostMessageFormat extends Record<string, unknown> = Record<string, unknown>,
->(
-  window: Window
-): MessageAdapter<ApolloClientDevtoolsMessage<PostMessageFormat>> {
+>(window: Window): MessageAdapter<PostMessageFormat> {
   const sentMessageIds = new Set<string>();
 
   return {

--- a/src/extension/messageAdapters.ts
+++ b/src/extension/messageAdapters.ts
@@ -4,9 +4,7 @@ import type { ApolloClientDevtoolsMessage } from "./messages";
 
 export interface MessageAdapter {
   addListener: (listener: (message: unknown) => void) => () => void;
-  postMessage: (
-    message: ApolloClientDevtoolsMessage<Record<string, unknown>>
-  ) => void;
+  postMessage: (message: ApolloClientDevtoolsMessage) => void;
 }
 
 export function createPortMessageAdapter(

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -4,7 +4,7 @@ import type { ApolloClientDevtoolsActorMessage } from "./actor";
 export const enum MessageType {
   RPCRequest = "rpcRequest",
   RPCResponse = "rpcResponse",
-  Event = "event",
+  Actor = "actor",
 }
 
 export type RPCRequestMessage<Params extends SafeAny[] = unknown[]> = {

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,11 +1,6 @@
 import type { SafeAny } from "../types";
 import type { ActorMessage } from "./actor";
 
-export interface MessageFormat {
-  type: string;
-  [key: string]: unknown;
-}
-
 export const enum MessageType {
   RPCRequest = "rpcRequest",
   RPCResponse = "rpcResponse",

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -93,7 +93,7 @@ type ClientTerminatedMessage = {
   clientId: string;
 };
 
-export type PanelMessage =
+export type EventMessage =
   | RegisterClientMessage
   | ClientTerminatedMessage
   | ExplorerRequestMessage
@@ -103,8 +103,6 @@ export type PanelMessage =
   | { type: "initializePanel" }
   | { type: "panelHidden" }
   | { type: "panelShown" };
-
-export type EventMessage = PanelMessage;
 
 export type DevtoolsRPCMessage = {
   getClients(): ApolloClientInfo[];

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -40,7 +40,7 @@ export type RPCMessage<
   Result = unknown,
 > = RPCRequestMessage<Params> | RPCResponseMessage<Result>;
 
-export type ApolloClientDevtoolsEventMessage = {
+export type ApolloClientDevtoolsActorMessage = {
   id: string;
   source: "apollo-client-devtools";
   type: MessageType.Event;
@@ -48,7 +48,7 @@ export type ApolloClientDevtoolsEventMessage = {
 };
 
 export type ApolloClientDevtoolsMessage =
-  | ApolloClientDevtoolsEventMessage
+  | ApolloClientDevtoolsActorMessage
   | RPCRequestMessage
   | RPCResponseMessage;
 

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -144,8 +144,8 @@ export function isRPCResponseMessage(
   return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
 }
 
-export function isEventMessage<Message extends Record<string, unknown>>(
+export function isEventMessage(
   message: unknown
-): message is ApolloClientDevtoolsEventMessage<Message> {
+): message is ApolloClientDevtoolsEventMessage<EventMessage> {
   return isDevtoolsMessage(message) && message.type === MessageType.Event;
 }

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -35,11 +35,6 @@ export type RPCResponseMessage<Result = unknown> =
   | RPCSuccessResponseMessage<Result>
   | RPCErrorResponseMessage;
 
-export type RPCMessage<
-  Params extends SafeAny[] = unknown[],
-  Result = unknown,
-> = RPCRequestMessage<Params> | RPCResponseMessage<Result>;
-
 export type ApolloClientDevtoolsMessage =
   | ApolloClientDevtoolsActorMessage
   | RPCRequestMessage

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -90,7 +90,7 @@ export function isRPCResponseMessage(
   return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
 }
 
-export function isEventMessage(
+export function isActorMessage(
   message: unknown
 ): message is ApolloClientDevtoolsEventMessage {
   return isDevtoolsMessage(message) && message.type === MessageType.Event;

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -2,6 +2,7 @@ import type { ApolloClientInfo, SafeAny } from "../types";
 import type { JSONObject } from "../application/types/json";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
 import type { ActorMessage } from "./actor";
+import type { ErrorCodes } from "@apollo/client/invariantErrorCodes";
 
 export interface MessageFormat {
   type: string;
@@ -65,6 +66,7 @@ export type DevtoolsRPCMessage = {
   getQueries(clientId: string): QueryDetails[];
   getMutations(clientId: string): MutationDetails[];
   getCache(clientId: string): JSONObject;
+  getErrorCodes(version: string): Promise<ErrorCodes | undefined>;
 };
 
 export function isDevtoolsMessage(

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,5 +1,5 @@
 import type { SafeAny } from "../types";
-import type { ActorMessage } from "./actor";
+import type { ApolloClientDevtoolsActorMessage } from "./actor";
 
 export const enum MessageType {
   RPCRequest = "rpcRequest",
@@ -39,13 +39,6 @@ export type RPCMessage<
   Params extends SafeAny[] = unknown[],
   Result = unknown,
 > = RPCRequestMessage<Params> | RPCResponseMessage<Result>;
-
-export type ApolloClientDevtoolsActorMessage = {
-  id: string;
-  source: "apollo-client-devtools";
-  type: MessageType.Event;
-  message: ActorMessage;
-};
 
 export type ApolloClientDevtoolsMessage =
   | ApolloClientDevtoolsActorMessage

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,8 +1,5 @@
-import type { ApolloClientInfo, SafeAny } from "../types";
-import type { JSONObject } from "../application/types/json";
-import type { MutationDetails, QueryDetails } from "./tab/helpers";
+import type { SafeAny } from "../types";
 import type { ActorMessage } from "./actor";
-import type { ErrorCodes } from "@apollo/client/invariantErrorCodes";
 
 export interface MessageFormat {
   type: string;
@@ -59,15 +56,6 @@ export type ApolloClientDevtoolsMessage =
   | ApolloClientDevtoolsEventMessage
   | RPCRequestMessage
   | RPCResponseMessage;
-
-export type DevtoolsRPCMessage = {
-  getClients(): ApolloClientInfo[];
-  getClient(id: string): ApolloClientInfo | null;
-  getQueries(clientId: string): QueryDetails[];
-  getMutations(clientId: string): MutationDetails[];
-  getCache(clientId: string): JSONObject;
-  getErrorCodes(version: string): Promise<ErrorCodes | undefined>;
-};
 
 export function isDevtoolsMessage(
   message: unknown

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -67,15 +67,3 @@ export function isDevtoolsMessage(
     message.source === "apollo-client-devtools"
   );
 }
-
-export function isRPCRequestMessage(
-  message: unknown
-): message is RPCRequestMessage {
-  return isDevtoolsMessage(message) && message.type === MessageType.RPCRequest;
-}
-
-export function isRPCResponseMessage(
-  message: unknown
-): message is RPCResponseMessage {
-  return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
-}

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,7 +1,7 @@
 import type { ApolloClientInfo, SafeAny } from "../types";
 import type { JSONObject } from "../application/types/json";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
-import type { EventMessage } from "./actor";
+import type { ActorMessage } from "./actor";
 
 export interface MessageFormat {
   type: string;
@@ -51,7 +51,7 @@ export type ApolloClientDevtoolsEventMessage = {
   id: string;
   source: "apollo-client-devtools";
   type: MessageType.Event;
-  message: EventMessage;
+  message: ActorMessage;
 };
 
 export type ApolloClientDevtoolsMessage =

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -89,9 +89,3 @@ export function isRPCResponseMessage(
 ): message is RPCResponseMessage {
   return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
 }
-
-export function isActorMessage(
-  message: unknown
-): message is ApolloClientDevtoolsEventMessage {
-  return isDevtoolsMessage(message) && message.type === MessageType.Event;
-}

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -93,13 +93,6 @@ type ClientTerminatedMessage = {
   clientId: string;
 };
 
-export type ClientMessage =
-  | RegisterClientMessage
-  | ClientTerminatedMessage
-  | ExplorerRequestMessage
-  | ExplorerResponseMessage
-  | ExplorerSubscriptionTerminationMessage;
-
 export type PanelMessage =
   | RegisterClientMessage
   | ClientTerminatedMessage
@@ -111,7 +104,7 @@ export type PanelMessage =
   | { type: "panelHidden" }
   | { type: "panelShown" };
 
-export type EventMessage = PanelMessage | ClientMessage;
+export type EventMessage = PanelMessage;
 
 export type DevtoolsRPCMessage = {
   getClients(): ApolloClientInfo[];

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -63,42 +63,21 @@ export type ApolloClientDevtoolsMessage<
   | RPCRequestMessage
   | RPCResponseMessage;
 
-type ExplorerRequestMessage = {
-  type: "explorerRequest";
-  payload: {
-    clientId: string;
-    operation: DocumentNode;
-    operationName: string | undefined;
-    variables: JSONObject | undefined;
-    fetchPolicy: FetchPolicy;
-  };
-};
-
-type ExplorerResponseMessage = {
-  type: "explorerResponse";
-  payload: ExplorerResponse;
-};
-
-type ExplorerSubscriptionTerminationMessage = {
-  type: "explorerSubscriptionTermination";
-};
-
-type RegisterClientMessage = {
-  type: "registerClient";
-  payload: ApolloClientInfo;
-};
-
-type ClientTerminatedMessage = {
-  type: "clientTerminated";
-  clientId: string;
-};
-
 export type EventMessage =
-  | RegisterClientMessage
-  | ClientTerminatedMessage
-  | ExplorerRequestMessage
-  | ExplorerResponseMessage
-  | ExplorerSubscriptionTerminationMessage
+  | { type: "registerClient"; payload: ApolloClientInfo }
+  | { type: "clientTerminated"; clientId: string }
+  | {
+      type: "explorerRequest";
+      payload: {
+        clientId: string;
+        operation: DocumentNode;
+        operationName: string | undefined;
+        variables: JSONObject | undefined;
+        fetchPolicy: FetchPolicy;
+      };
+    }
+  | { type: "explorerResponse"; payload: ExplorerResponse }
+  | { type: "explorerSubscriptionTermination" }
   | { type: "pageNavigated" }
   | { type: "initializePanel" }
   | { type: "panelHidden" }

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -47,19 +47,15 @@ export type RPCMessage<
   Result = unknown,
 > = RPCRequestMessage<Params> | RPCResponseMessage<Result>;
 
-export type ApolloClientDevtoolsEventMessage<
-  Message extends Record<string, unknown> = Record<string, unknown>,
-> = {
+export type ApolloClientDevtoolsEventMessage = {
   id: string;
   source: "apollo-client-devtools";
   type: MessageType.Event;
-  message: Message;
+  message: EventMessage;
 };
 
-export type ApolloClientDevtoolsMessage<
-  Message extends Record<string, unknown> = Record<string, unknown>,
-> =
-  | ApolloClientDevtoolsEventMessage<Message>
+export type ApolloClientDevtoolsMessage =
+  | ApolloClientDevtoolsEventMessage
   | RPCRequestMessage
   | RPCResponseMessage;
 
@@ -91,9 +87,9 @@ export type DevtoolsRPCMessage = {
   getCache(clientId: string): JSONObject;
 };
 
-export function isDevtoolsMessage<Message extends Record<string, unknown>>(
+export function isDevtoolsMessage(
   message: unknown
-): message is ApolloClientDevtoolsMessage<Message> {
+): message is ApolloClientDevtoolsMessage {
   return (
     typeof message === "object" &&
     message !== null &&
@@ -116,6 +112,6 @@ export function isRPCResponseMessage(
 
 export function isEventMessage(
   message: unknown
-): message is ApolloClientDevtoolsEventMessage<EventMessage> {
+): message is ApolloClientDevtoolsEventMessage {
   return isDevtoolsMessage(message) && message.type === MessageType.Event;
 }

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -111,6 +111,8 @@ export type PanelMessage =
   | { type: "panelHidden" }
   | { type: "panelShown" };
 
+export type EventMessage = PanelMessage | ClientMessage;
+
 export type DevtoolsRPCMessage = {
   getClients(): ApolloClientInfo[];
   getClient(id: string): ApolloClientInfo | null;

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,7 +1,7 @@
-import type { ApolloClientInfo, ExplorerResponse, SafeAny } from "../types";
+import type { ApolloClientInfo, SafeAny } from "../types";
 import type { JSONObject } from "../application/types/json";
-import type { FetchPolicy, DocumentNode } from "@apollo/client";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
+import type { EventMessage } from "./actor";
 
 export interface MessageFormat {
   type: string;
@@ -58,26 +58,6 @@ export type ApolloClientDevtoolsMessage =
   | ApolloClientDevtoolsEventMessage
   | RPCRequestMessage
   | RPCResponseMessage;
-
-export type EventMessage =
-  | { type: "registerClient"; payload: ApolloClientInfo }
-  | { type: "clientTerminated"; clientId: string }
-  | {
-      type: "explorerRequest";
-      payload: {
-        clientId: string;
-        operation: DocumentNode;
-        operationName: string | undefined;
-        variables: JSONObject | undefined;
-        fetchPolicy: FetchPolicy;
-      };
-    }
-  | { type: "explorerResponse"; payload: ExplorerResponse }
-  | { type: "explorerSubscriptionTermination" }
-  | { type: "pageNavigated" }
-  | { type: "initializePanel" }
-  | { type: "panelHidden" }
-  | { type: "panelShown" };
 
 export type DevtoolsRPCMessage = {
   getClients(): ApolloClientInfo[];

--- a/src/extension/messages.ts
+++ b/src/extension/messages.ts
@@ -1,39 +1,11 @@
-import type { SafeAny } from "../types";
 import type { ApolloClientDevtoolsActorMessage } from "./actor";
+import type { RPCRequestMessage, RPCResponseMessage } from "./rpc";
 
 export const enum MessageType {
   RPCRequest = "rpcRequest",
   RPCResponse = "rpcResponse",
   Actor = "actor",
 }
-
-export type RPCRequestMessage<Params extends SafeAny[] = unknown[]> = {
-  source: "apollo-client-devtools";
-  type: MessageType.RPCRequest;
-  id: string;
-  name: string;
-  params: Params;
-};
-
-export type RPCErrorResponseMessage = {
-  source: "apollo-client-devtools";
-  type: MessageType.RPCResponse;
-  id: string;
-  sourceId: string;
-  error: { name?: string; message: string; stack?: string };
-};
-
-export type RPCSuccessResponseMessage<Result = unknown> = {
-  source: "apollo-client-devtools";
-  type: MessageType.RPCResponse;
-  id: string;
-  sourceId: string;
-  result: Result;
-};
-
-export type RPCResponseMessage<Result = unknown> =
-  | RPCSuccessResponseMessage<Result>
-  | RPCErrorResponseMessage;
 
 export type ApolloClientDevtoolsMessage =
   | ApolloClientDevtoolsActorMessage

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -1,14 +1,26 @@
-import type { NoInfer, SafeAny } from "../types";
+import type { ErrorCodes } from "@apollo/client/invariantErrorCodes";
+import type { JSONObject } from "../application/types/json";
+import type { ApolloClientInfo, NoInfer, SafeAny } from "../types";
 import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type { DevtoolsRPCMessage, RPCRequestMessage } from "./messages";
+import type { RPCRequestMessage } from "./messages";
 import {
   MessageType,
   isRPCRequestMessage,
   isRPCResponseMessage,
 } from "./messages";
+import type { MutationDetails, QueryDetails } from "./tab/helpers";
+
+export type DevtoolsRPCMessage = {
+  getClients(): ApolloClientInfo[];
+  getClient(id: string): ApolloClientInfo | null;
+  getQueries(clientId: string): QueryDetails[];
+  getMutations(clientId: string): MutationDetails[];
+  getCache(clientId: string): JSONObject;
+  getErrorCodes(version: string): Promise<ErrorCodes | undefined>;
+};
 
 export interface RpcClient {
   readonly timeout: number;

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -5,7 +5,6 @@ import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type { RPCRequestMessage, RPCResponseMessage } from "./messages";
 import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
 
@@ -26,6 +25,34 @@ export interface RpcClient {
     ...params: Parameters<DevtoolsRPCMessage[TName]>
   ) => Promise<Awaited<ReturnType<DevtoolsRPCMessage[TName]>>>;
 }
+
+type RPCErrorResponseMessage = {
+  source: "apollo-client-devtools";
+  type: MessageType.RPCResponse;
+  id: string;
+  sourceId: string;
+  error: { name?: string; message: string; stack?: string };
+};
+
+type RPCSuccessResponseMessage<Result = unknown> = {
+  source: "apollo-client-devtools";
+  type: MessageType.RPCResponse;
+  id: string;
+  sourceId: string;
+  result: Result;
+};
+
+export type RPCRequestMessage<Params extends SafeAny[] = unknown[]> = {
+  source: "apollo-client-devtools";
+  type: MessageType.RPCRequest;
+  id: string;
+  name: string;
+  params: Params;
+};
+
+export type RPCResponseMessage<Result = unknown> =
+  | RPCSuccessResponseMessage<Result>
+  | RPCErrorResponseMessage;
 
 const DEFAULT_TIMEOUT = 30_000;
 

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -8,7 +8,7 @@ import type { MessageAdapter } from "./messageAdapters";
 import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
 
-export type DevtoolsRPCMessage = {
+export type RPCRequest = {
   getClients(): ApolloClientInfo[];
   getClient(id: string): ApolloClientInfo | null;
   getQueries(clientId: string): QueryDetails[];
@@ -20,10 +20,10 @@ export type DevtoolsRPCMessage = {
 export interface RpcClient {
   readonly timeout: number;
   withTimeout: (timeoutMs: number) => RpcClient;
-  request: <TName extends keyof DevtoolsRPCMessage & string>(
+  request: <TName extends keyof RPCRequest & string>(
     name: TName,
-    ...params: Parameters<DevtoolsRPCMessage[TName]>
-  ) => Promise<Awaited<ReturnType<DevtoolsRPCMessage[TName]>>>;
+    ...params: Parameters<RPCRequest[TName]>
+  ) => Promise<Awaited<ReturnType<RPCRequest[TName]>>>;
 }
 
 type RPCErrorResponseMessage = {
@@ -121,13 +121,13 @@ export function createRpcHandler(adapter: MessageAdapter) {
     }
   }
 
-  return function <TName extends keyof DevtoolsRPCMessage & string>(
+  return function <TName extends keyof RPCRequest & string>(
     name: TName,
     handler: (
-      ...params: Parameters<DevtoolsRPCMessage[TName]>
+      ...params: Parameters<RPCRequest[TName]>
     ) =>
-      | NoInfer<Awaited<ReturnType<DevtoolsRPCMessage[TName]>>>
-      | Promise<NoInfer<Awaited<ReturnType<DevtoolsRPCMessage[TName]>>>>
+      | NoInfer<Awaited<ReturnType<RPCRequest[TName]>>>
+      | Promise<NoInfer<Awaited<ReturnType<RPCRequest[TName]>>>>
   ) {
     if (listeners.has(name)) {
       throw new Error("Only one rpc handler can be registered per type");
@@ -136,7 +136,7 @@ export function createRpcHandler(adapter: MessageAdapter) {
     listeners.set(name, async ({ id, params }) => {
       try {
         const result = await Promise.resolve(
-          handler(...(params as Parameters<DevtoolsRPCMessage[TName]>))
+          handler(...(params as Parameters<RPCRequest[TName]>))
         );
 
         adapter.postMessage({

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -5,12 +5,8 @@ import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type { RPCRequestMessage } from "./messages";
-import {
-  MessageType,
-  isRPCRequestMessage,
-  isRPCResponseMessage,
-} from "./messages";
+import type { RPCRequestMessage, RPCResponseMessage } from "./messages";
+import { MessageType, isDevtoolsMessage } from "./messages";
 import type { MutationDetails, QueryDetails } from "./tab/helpers";
 
 export type DevtoolsRPCMessage = {
@@ -144,4 +140,14 @@ export function createRpcHandler(adapter: MessageAdapter) {
       }
     };
   };
+}
+
+export function isRPCRequestMessage(
+  message: unknown
+): message is RPCRequestMessage {
+  return isDevtoolsMessage(message) && message.type === MessageType.RPCRequest;
+}
+
+function isRPCResponseMessage(message: unknown): message is RPCResponseMessage {
+  return isDevtoolsMessage(message) && message.type === MessageType.RPCResponse;
 }

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -3,7 +3,7 @@ import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type { RPCRequestMessage, RPCResponseMessage } from "./messages";
+import type { RPCRequestMessage } from "./messages";
 import {
   MessageType,
   isRPCRequestMessage,
@@ -24,7 +24,7 @@ export interface RpcClient<Messages extends MessageCollection> {
 const DEFAULT_TIMEOUT = 30_000;
 
 export function createRpcClient<Messages extends MessageCollection>(
-  adapter: MessageAdapter<RPCRequestMessage>
+  adapter: MessageAdapter
 ): RpcClient<Messages> {
   return {
     timeout: DEFAULT_TIMEOUT,
@@ -68,7 +68,7 @@ export function createRpcClient<Messages extends MessageCollection>(
 }
 
 export function createRpcHandler<Messages extends MessageCollection>(
-  adapter: MessageAdapter<RPCResponseMessage>
+  adapter: MessageAdapter
 ) {
   const listeners = new Map<string, (message: RPCRequestMessage) => void>();
   let removeListener: (() => void) | null = null;

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -3,7 +3,7 @@ import { createId } from "../utils/createId";
 import { RPC_MESSAGE_TIMEOUT } from "./errorMessages";
 import { deserializeError, serializeError } from "./errorSerialization";
 import type { MessageAdapter } from "./messageAdapters";
-import type { RPCRequestMessage } from "./messages";
+import type { DevtoolsRPCMessage, RPCRequestMessage } from "./messages";
 import {
   MessageType,
   isRPCRequestMessage,
@@ -12,20 +12,18 @@ import {
 
 type MessageCollection = Record<string, (...parameters: SafeAny[]) => SafeAny>;
 
-export interface RpcClient<Messages extends MessageCollection> {
+export interface RpcClient {
   readonly timeout: number;
-  withTimeout: (timeoutMs: number) => RpcClient<Messages>;
-  request: <TName extends keyof Messages & string>(
+  withTimeout: (timeoutMs: number) => RpcClient;
+  request: <TName extends keyof DevtoolsRPCMessage & string>(
     name: TName,
-    ...params: Parameters<Messages[TName]>
-  ) => Promise<Awaited<ReturnType<Messages[TName]>>>;
+    ...params: Parameters<DevtoolsRPCMessage[TName]>
+  ) => Promise<Awaited<ReturnType<DevtoolsRPCMessage[TName]>>>;
 }
 
 const DEFAULT_TIMEOUT = 30_000;
 
-export function createRpcClient<Messages extends MessageCollection>(
-  adapter: MessageAdapter
-): RpcClient<Messages> {
+export function createRpcClient(adapter: MessageAdapter): RpcClient {
   return {
     timeout: DEFAULT_TIMEOUT,
     withTimeout(timeoutMs) {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -23,10 +23,8 @@ import type { ApolloClientInfo, QueryResult, SafeAny } from "../../types";
 import { getPrivateAccess } from "../../privateAccess";
 import type { JSONObject } from "../../application/types/json";
 import { createWindowActor } from "../actor";
-import type { DevtoolsRPCMessage } from "../messages";
 import { createWindowMessageAdapter } from "../messageAdapters";
 import { createRpcClient, createRpcHandler } from "../rpc";
-import type { ErrorCodesHandler } from "../background/errorcodes";
 import { loadErrorCodes } from "./loadErrorCodes";
 import { createId } from "../../utils/createId";
 
@@ -53,7 +51,7 @@ const DEVTOOLS_KEY = Symbol.for("apollo.devtools");
 
 const tab = createWindowActor(window);
 const messageAdapter = createWindowMessageAdapter(window);
-const handleRpc = createRpcHandler<DevtoolsRPCMessage>(messageAdapter);
+const handleRpc = createRpcHandler(messageAdapter);
 const rpcClient = createRpcClient(messageAdapter);
 
 function getQueriesForClient(client: ApolloClient<unknown> | undefined) {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -54,7 +54,7 @@ const DEVTOOLS_KEY = Symbol.for("apollo.devtools");
 const tab = createWindowActor(window);
 const messageAdapter = createWindowMessageAdapter(window);
 const handleRpc = createRpcHandler<DevtoolsRPCMessage>(messageAdapter);
-const rpcClient = createRpcClient<ErrorCodesHandler>(messageAdapter);
+const rpcClient = createRpcClient(messageAdapter);
 
 function getQueriesForClient(client: ApolloClient<unknown> | undefined) {
   const ac = getPrivateAccess(client);

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -23,7 +23,7 @@ import type { ApolloClientInfo, QueryResult, SafeAny } from "../../types";
 import { getPrivateAccess } from "../../privateAccess";
 import type { JSONObject } from "../../application/types/json";
 import { createWindowActor } from "../actor";
-import type { ClientMessage, DevtoolsRPCMessage } from "../messages";
+import type { DevtoolsRPCMessage } from "../messages";
 import { createWindowMessageAdapter } from "../messageAdapters";
 import { createRpcClient, createRpcHandler } from "../rpc";
 import type { ErrorCodesHandler } from "../background/errorcodes";
@@ -51,7 +51,7 @@ type Hook = {
 
 const DEVTOOLS_KEY = Symbol.for("apollo.devtools");
 
-const tab = createWindowActor<ClientMessage>(window);
+const tab = createWindowActor(window);
 const messageAdapter = createWindowMessageAdapter(window);
 const handleRpc = createRpcHandler<DevtoolsRPCMessage>(messageAdapter);
 const rpcClient = createRpcClient<ErrorCodesHandler>(messageAdapter);

--- a/src/extension/tab/loadErrorCodes.ts
+++ b/src/extension/tab/loadErrorCodes.ts
@@ -1,11 +1,7 @@
 import type { ErrorCodes } from "@apollo/client/invariantErrorCodes";
 import type { RpcClient } from "../rpc";
-import type { ErrorCodesHandler } from "../background/errorcodes";
 
-export function loadErrorCodes(
-  rpcClient: RpcClient<ErrorCodesHandler>,
-  version: string
-) {
+export function loadErrorCodes(rpcClient: RpcClient, version: string) {
   rpcClient
     .request("getErrorCodes", version)
     .catch(() => {})

--- a/src/testUtils/testMessageAdapter.ts
+++ b/src/testUtils/testMessageAdapter.ts
@@ -8,7 +8,7 @@ import type {
 import type { SafeAny } from "../types";
 import { createId } from "../utils/createId";
 
-interface TestAdapter extends MessageAdapter<RPCResponseMessage> {
+interface TestAdapter extends MessageAdapter {
   mocks: { messages: unknown[] };
   postMessage: jest.Mock<void, [message: unknown]>;
   mockClear: () => void;

--- a/src/testUtils/testMessageAdapter.ts
+++ b/src/testUtils/testMessageAdapter.ts
@@ -1,9 +1,6 @@
 import type { MessageAdapter } from "../extension/messageAdapters";
 import { MessageType } from "../extension/messages";
-import type {
-  RPCRequestMessage,
-  RPCResponseMessage,
-} from "../extension/messages";
+import type { RPCRequestMessage, RPCResponseMessage } from "../extension/rpc";
 import { isRPCRequestMessage, type DevtoolsRPCMessage } from "../extension/rpc";
 import type { SafeAny } from "../types";
 import { createId } from "../utils/createId";

--- a/src/testUtils/testMessageAdapter.ts
+++ b/src/testUtils/testMessageAdapter.ts
@@ -1,10 +1,10 @@
 import type { MessageAdapter } from "../extension/messageAdapters";
 import { isRPCRequestMessage, MessageType } from "../extension/messages";
 import type {
-  DevtoolsRPCMessage,
   RPCRequestMessage,
   RPCResponseMessage,
 } from "../extension/messages";
+import type { DevtoolsRPCMessage } from "../extension/rpc";
 import type { SafeAny } from "../types";
 import { createId } from "../utils/createId";
 

--- a/src/testUtils/testMessageAdapter.ts
+++ b/src/testUtils/testMessageAdapter.ts
@@ -1,10 +1,10 @@
 import type { MessageAdapter } from "../extension/messageAdapters";
-import { isRPCRequestMessage, MessageType } from "../extension/messages";
+import { MessageType } from "../extension/messages";
 import type {
   RPCRequestMessage,
   RPCResponseMessage,
 } from "../extension/messages";
-import type { DevtoolsRPCMessage } from "../extension/rpc";
+import { isRPCRequestMessage, type DevtoolsRPCMessage } from "../extension/rpc";
 import type { SafeAny } from "../types";
 import { createId } from "../utils/createId";
 

--- a/src/testUtils/testMessageAdapter.ts
+++ b/src/testUtils/testMessageAdapter.ts
@@ -1,7 +1,7 @@
 import type { MessageAdapter } from "../extension/messageAdapters";
 import { MessageType } from "../extension/messages";
 import type { RPCRequestMessage, RPCResponseMessage } from "../extension/rpc";
-import { isRPCRequestMessage, type DevtoolsRPCMessage } from "../extension/rpc";
+import { isRPCRequestMessage, type RPCRequest } from "../extension/rpc";
 import type { SafeAny } from "../types";
 import { createId } from "../utils/createId";
 
@@ -9,11 +9,11 @@ interface TestAdapter extends MessageAdapter {
   mocks: { messages: unknown[] };
   postMessage: jest.Mock<void, [message: unknown]>;
   mockClear: () => void;
-  handleRpcRequest: <TName extends keyof DevtoolsRPCMessage>(
+  handleRpcRequest: <TName extends keyof RPCRequest>(
     name: TName,
     callback: (
-      ...args: Parameters<DevtoolsRPCMessage[TName]>
-    ) => ReturnType<DevtoolsRPCMessage[TName]>
+      ...args: Parameters<RPCRequest[TName]>
+    ) => ReturnType<RPCRequest[TName]>
   ) => void;
 }
 


### PR DESCRIPTION
I saw an opportunity to simplify the message types in the app. We use a ton of generics with both the actor and RPC models, but looking through this more, this seemed largely unnecessary because we don't have messages going a bunch of different ways to different things. We largely want to create a single actor/rpc client and use that for messaging in a specific area of the extension.

As a part of this, I decided to simplify the types and remove the need for generics. I've combined the message types together into a single union type that has now moved to the respective files where the implementation lives. This should make it easier to know both where to put the type and avoid confusion on what message type should include new types.