### PR TITLE
Use `with` for JSON import attribute

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ import CopyPlugin from "copy-webpack-plugin";
 import TerserPlugin from "terser-webpack-plugin";
 import WebExtPlugin from "web-ext-plugin";
 import webpack from "webpack";
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 


### PR DESCRIPTION
Node 22 has removed support for the `assert` keyword here.

No changelog since this is a build tooling change only.