### PR TITLE
JSON parse/stringify cache data in queries to avoid serialization error

### DIFF
--- a/.changeset/little-otters-listen.md
+++ b/.changeset/little-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix issue serializing cache data for the queries tab when the cache contains irregular data.

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -15,6 +15,7 @@ import { getPrivateAccess } from "../../privateAccess";
 import { getOperationName } from "@apollo/client/utilities";
 import { pick } from "../../application/utilities/pick";
 import type { GraphQLFormattedError } from "graphql";
+import type { JSONObject } from "../../application/types/json";
 
 export type QueryOptions = Pick<
   WatchQueryOptions,
@@ -84,7 +85,7 @@ export function getQueries(
         id: queryId,
         document,
         variables,
-        cachedData: diff.result,
+        cachedData: JSON.parse(JSON.stringify(diff.result ?? {})) as JSONObject,
         options: getQueryOptions(oc),
         networkStatus,
         error: error ? serializeApolloError(error) : undefined,


### PR DESCRIPTION
Fixes #1479

https://github.com/apollographql/apollo-client-devtools/pull/1418 did an optimization where only the data for the tab you're viewing is transferred between the content scripts and devtools. That data used to all be sent together and serialization errors were avoided by running a `JSON.parse(JSON.stringify(...))` on the entire data set. In making the change in #1418 however, it now only applies this to the cache tab data. We also send cache data for the queries tab which needs this fix as well.