### PR TITLE
Fix issue cloning objects when sending client payloads - attempt 2

### DIFF
--- a/.changeset/swift-otters-train.md
+++ b/.changeset/swift-otters-train.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Always JSON serialize payloads sent from the injected script to avoid issues cloning irregular objects in client data.

--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -85,7 +85,7 @@ export function getQueries(
         id: queryId,
         document,
         variables,
-        cachedData: JSON.parse(JSON.stringify(diff.result ?? {})) as JSONObject,
+        cachedData: diff.result,
         options: getQueryOptions(oc),
         networkStatus,
         error: error ? serializeApolloError(error) : undefined,

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -140,17 +140,7 @@ handleRpc("getMutations", (clientId) =>
 );
 
 handleRpc("getCache", (clientId) => {
-  // We need to JSON stringify the data here in case the cache contains
-  // references to irregular data such as `URL` instances which are not
-  // cloneable via `structuredClone` (which `window.postMessage` uses to
-  // send messages). `JSON.stringify` does however serialize `URL`s into
-  // strings properly, so this should ensure that the cache data will be
-  // sent without errors.
-  //
-  // https://github.com/apollographql/apollo-client-devtools/issues/1258
-  return JSON.parse(
-    JSON.stringify(getClientById(clientId)?.cache.extract(true) ?? {})
-  ) as JSONObject;
+  return getClientById(clientId)?.cache.extract(true) ?? {};
 });
 
 function getClientById(clientId: string) {

--- a/src/extension/tab/hook.ts
+++ b/src/extension/tab/hook.ts
@@ -50,7 +50,9 @@ type Hook = {
 const DEVTOOLS_KEY = Symbol.for("apollo.devtools");
 
 const tab = createWindowActor(window);
-const messageAdapter = createWindowMessageAdapter(window);
+const messageAdapter = createWindowMessageAdapter(window, {
+  jsonSerialize: true,
+});
 const handleRpc = createRpcHandler(messageAdapter);
 const rpcClient = createRpcClient(messageAdapter);
 


### PR DESCRIPTION
Fixes #1479

Attempt 2 at fixing the issue of sending data from the client into devtools. This solution opts to `JSON.parse(JSON.stringify(...))` every message sent from the injected script so that we don't forget to do this for additional payloads in the future.