### PR TITLE
remove empty page_action property in manifest.json for chrome

### DIFF
--- a/src/extension/chrome/manifest.json
+++ b/src/extension/chrome/manifest.json
@@ -8,7 +8,6 @@
     "128": "images/logo128.png",
     "400": "images/logo400.png"
   },
-  "page_action": {},
   "devtools_page": "devtools.html",
   "background": { "service_worker": "service_worker.js" },
   "web_accessible_resources": [


### PR DESCRIPTION
## got

I got an error `'page_action' requires manifest version of 2 or lower.` on chrome extension settings `chrome://extensions/` when I add this extension which built in local machine `npm run build -- --env TARGET=chrome`

![image](https://github.com/user-attachments/assets/e0be86d8-ca2a-40b9-aed5-1b1778b464d7)

## expected

no errors on chrome extension settings `chrome://extensions/` for this extension

## what I done

I removed `page_action` property because it was empty

(FYI `page_action` is changed to `action` in Manifest V3 https://developer.chrome.com/docs/extensions/develop/migrate/api-calls#replace_browser_action_and_page_action_with_action so use `action` if it will be needed)
