### PR TITLE
wrap `injectScript` call in `try..catch`, offer extension builds as PR artifacts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,10 +19,50 @@ jobs:
       - run: npm ci
 
       # Build and output bunle stats to webpack-stats.json
-      - run: yarn build --env TARGET=chrome --json webpack-stats.json
+      - run: WEBPACK_BUILD_ARGS="--json webpack-stats.json" npm run dist:chrome
 
       # Upload webpack-stats.json to use on relative-ci.yaml workflow
       - name: Upload webpack stats artifact
         uses: relative-ci/agent-upload-artifact-action@v2
         with:
           webpackStatsFile: ./webpack-stats.json
+
+      - uses: actions/upload-artifact@v4
+        id: chrome-artifact
+        with:
+          name: apollo-client-devtools-chrome
+          path: apollo-client-devtools-chrome.zip
+          retention-days: 14
+
+      # Build and output bunle stats to webpack-stats.json
+      - run: npm run dist:firefox
+
+      - uses: actions/upload-artifact@v4
+        id: firefox-artifact
+        with:
+          name: apollo-client-devtools-firefox
+          path: apollo-client-devtools-firefox.zip
+          retention-days: 14
+
+      - name: Output artifact URLs
+        run: echo "Artifact URLs are \n${{ steps.chrome-artifact.outputs.artifact-url }}\n and \n${{ steps.firefox-artifact.outputs.artifact-url }}\n"
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: <!-- ARTIFACT-DOWNLOAD -->
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- ARTIFACT-DOWNLOAD -->
+            You can download the latest builds of the extension for this PR here:
+            * [Chrome](${{ steps.chrome-artifact.outputs.artifact-url }})
+            * [Firefox](${{ steps.firefox-artifact.outputs.artifact-url }})

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         id: chrome-artifact
         with:
-          name: apollo-client-devtools-chrome
+          name: devtools-chrome
           path: apollo-client-devtools-chrome.zip
           retention-days: 14
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         id: firefox-artifact
         with:
-          name: apollo-client-devtools-firefox
+          name: devtools-firefox
           path: apollo-client-devtools-firefox.zip
           retention-days: 14
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:dev": "run-p start:client start:server",
     "dist:chrome": "npm run build -- --env TARGET=chrome && tsx build.ts chrome",
     "dist:firefox": "npm run build -- --env TARGET=firefox && tsx build.ts firefox",
-    "build": "npm run clean && webpack --env NODE_ENV=production --progress",
+    "build": "npm run clean && webpack --env NODE_ENV=production --progress $WEBPACK_BUILD_ARGS",
     "build:dev": "npm run clean && webpack --env NODE_ENV=development --progress",
     "clean": "rimraf build && mkdir build && rimraf *.zip",
     "changeset-publish": "npm run build -- --env TARGET=firefox && changeset publish",

--- a/src/extension/tab/tab.ts
+++ b/src/extension/tab/tab.ts
@@ -50,5 +50,12 @@ if (__IS_FIREFOX__) {
     }
   }
 
-  injectScript(browser.runtime.getURL("hook.js"));
+  try {
+    injectScript(browser.runtime.getURL("hook.js"));
+  } catch (e) {
+    console.warn(
+      "Error occured while trying to initialize Apollo Client Devtools:",
+      e
+    );
+  }
 }


### PR DESCRIPTION
This *might* resolve #1519.

Also adding a "download build extension" comment to future PRs with this, which would make it easier to get quick user feedback.