### PR TITLE
fix: Output webpack-stats.json using webpack-stats-plugin

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
 
       # Build and output bunle stats to webpack-stats.json
-      - run: yarn build --env TARGET=chrome --json webpack-stats.json
+      - run: yarn build --env TARGET=chrome
 
       # Upload webpack-stats.json to use on relative-ci.yaml workflow
       - name: Upload webpack stats artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "webextension-polyfill": "0.12.0",
         "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
+        "webpack-stats-plugin": "^1.1.3",
         "ws": "^8.18.0"
       }
     },
@@ -27375,6 +27376,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webpack-stats-plugin": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.1.3.tgz",
+      "integrity": "sha512-yUKYyy+e0iF/w31QdfioRKY+h3jDBRpthexBOWGKda99iu2l/wxYsI/XqdlP5IU58/0KB9CsJZgWNAl+/MPkRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/graceful-fs": {
       "version": "4.2.11",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "webextension-polyfill": "0.12.0",
     "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
+    "webpack-stats-plugin": "1.1.3",
     "ws": "^8.18.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ import url from "url";
 import CopyPlugin from "copy-webpack-plugin";
 import TerserPlugin from "terser-webpack-plugin";
 import WebExtPlugin from "web-ext-plugin";
+import { StatsWriterPlugin } from "webpack-stats-plugin";
 import webpack from "webpack";
 import packageJson from "./package.json" with { type: "json" };
 
@@ -39,6 +40,19 @@ export default /** @returns {import("webpack").Configuration} */ (env) => {
       __IS_VSCODE__: IS_VSCODE,
     }),
   ];
+
+  if (env.NODE_ENV === "production") {
+    plugins.push(
+      new StatsWriterPlugin({
+        filename: "../webpack-stats.json",
+        stats: {
+          assets: true,
+          chunks: true,
+          modules: true,
+        },
+      })
+    );
+  }
 
   if (IS_EXTENSION) {
     plugins.push(


### PR DESCRIPTION
Output webpack-stats.json for a single configuration. The webpack-cli json output for multiple configurations [is not supported](https://relative-ci.com/documentation/guides/bundle-stats/webpack-cli-webpack-stats#multiple-configuration-support).

[before](https://github.com/apollographql/apollo-client-devtools/actions/runs/10973590058/job/30471145838):

```shell
Send stats to RelativeCI branch=renovate/peter-evans-create-pull-request-7.x commit=4ccc00b79d3140a0adb54af3670f72ecf7e0c02e
{
  code: 'BadRequest',
  message: 'Invalid webpack stats structure, please make sure webpack stats configuration is correct.\n' +
    '\n' +
    'Expected a nonempty array but received an empty one\n' +
    'Path: assets\n' +
    'Failed structure(assets): []'
```

[after](https://github.com/vio/apollo-client-devtools/actions/runs/10974342006/job/30472754971):

```shell
Send stats to RelativeCI branch=fix-webpack-stats-output commit=c4fa1d96824e7c584374276372c574817d2a5148
Job #2 done.
Bundle Size — 1.6MiB (+100%).
```