### PR TITLE
Fix issue where data would sometimes stop updating after a page refresh

### DIFF
--- a/.changeset/hip-pants-wonder.md
+++ b/.changeset/hip-pants-wonder.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix an issue where refreshing the page would sometimes cause client data to stop updating.

--- a/src/application/App.tsx
+++ b/src/application/App.tsx
@@ -80,9 +80,8 @@ export const App = () => {
   const [snapshot, send] = useMachine(
     devtoolsMachine.provide({
       actions: {
-        resetStore: async () => {
-          await apolloClient.clearStore().catch(noop);
-          refetch().catch(noop);
+        resetStore: () => {
+          apolloClient.clearStore().catch(noop);
         },
       },
     })


### PR DESCRIPTION
Fixes #1522

When refreshing the page, data would stop updating from time to time. Sometimes I could reproduce consistently and others I could only reproduce every now and then.

I suspect the issue here is that the `refetch` from the client sets the `pollInterval` back to `0`, so we stop sending messages to get new data from the client. For now I've removed this as it doesn't seem to have any effect anyways.