### PR TITLE
Ensure `graphqlErrors` always returns a value

### DIFF
--- a/src/extension/tab/helpers.ts
+++ b/src/extension/tab/helpers.ts
@@ -103,7 +103,7 @@ function serializeApolloError(error: ApolloError): SerializedApolloError {
       ? serializeError(error.networkError)
       : undefined,
     message: error.message,
-    graphQLErrors: error.graphQLErrors,
+    graphQLErrors: error.graphQLErrors ?? [],
     protocolErrors: error.protocolErrors?.map((e) => e.message) ?? [],
   };
 }


### PR DESCRIPTION
Fixes #1552

I have been unable to reproduce this myself since `ApolloError.graphQLErrors` is supposed to always be an array, but I've added a defensive fallback when serializing the error to ensure we always have a value.