### PR TITLE
Fix explorer infinite loading when errors are returned

### DIFF
--- a/.changeset/yellow-eyes-look.md
+++ b/.changeset/yellow-eyes-look.md
@@ -1,0 +1,5 @@
+---
+"apollo-client-devtools": patch
+---
+
+Fix an issue where executing a query in the explorer tab that returned errors would get stuck in the loading state indefinitely.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@apollo/brand": "^0.7.0",
-        "@apollo/client": "4.0.3",
+        "@apollo/client": "4.0.5",
         "@apollo/client-3": "npm:@apollo/client@3.14.0",
         "@apollo/icons": "^0.8.0",
         "@apollo/tailwind-preset": "^0.2.0",
@@ -236,9 +236,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@apollo/client": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.3.tgz",
-      "integrity": "sha512-XCrNpBwVymRLEUbMjiP4WGmeNnP9bRhqX7ZqlEvZRAkYFvLPQyI65/ldAFvyfTnI4vjRLgpkwGKqW2+BelPEiw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.5.tgz",
+      "integrity": "sha512-H0FQXa6MRWQS0/jNv4VO6NfUWueZ4L7QYjkbSztADpugb4yTzRBVVwFq5mL3FJVJWewxWVrzJof/yzCTVTsXaw==",
       "license": "MIT",
       "workspaces": [
         "dist",
@@ -27165,12 +27165,12 @@
       }
     },
     "packages/apollo-client-devtools": {
-      "version": "4.20.2",
+      "version": "4.21.4",
       "license": "MIT"
     },
     "packages/client-devtools-vscode": {
       "name": "@apollo/client-devtools-vscode",
-      "version": "4.20.2",
+      "version": "4.21.4",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14103,6 +14103,8 @@
     },
     "node_modules/graphql": {
       "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@apollo/brand": "^0.7.0",
-    "@apollo/client": "4.0.3",
+    "@apollo/client": "4.0.5",
     "@apollo/client-3": "npm:@apollo/client@3.14.0",
     "@apollo/icons": "^0.8.0",
     "@apollo/tailwind-preset": "^0.2.0",

--- a/src/extension/tab/v4/handler.ts
+++ b/src/extension/tab/v4/handler.ts
@@ -3,6 +3,7 @@ import type {
   CombinedProtocolErrors,
   LocalStateError,
 } from "@apollo/client";
+import { isNetworkRequestSettled } from "@apollo/client/utilities";
 import type {
   ApolloClient,
   DocumentNode,
@@ -98,7 +99,7 @@ export class ClientV4Handler extends ClientHandler<ApolloClient> {
     fetchPolicy: FetchPolicy;
   }): Observable<EmbeddedExplorerResponse> {
     return this.client.watchQuery<JSONObject>(options).pipe(
-      filter((result) => result.dataState !== "empty"),
+      filter((result) => isNetworkRequestSettled(result.networkStatus)),
       map(
         (result): EmbeddedExplorerResponse => ({
           data: result.data,

--- a/src/extension/tab/v4/handler.ts
+++ b/src/extension/tab/v4/handler.ts
@@ -99,7 +99,11 @@ export class ClientV4Handler extends ClientHandler<ApolloClient> {
     fetchPolicy: FetchPolicy;
   }): Observable<EmbeddedExplorerResponse> {
     return this.client.watchQuery<JSONObject>(options).pipe(
-      filter((result) => isNetworkRequestSettled(result.networkStatus)),
+      filter(
+        (result) =>
+          isNetworkRequestSettled(result.networkStatus) ||
+          result.dataState !== "empty"
+      ),
       map(
         (result): EmbeddedExplorerResponse => ({
           data: result.data,

--- a/src/extension/tab/v4/handler.ts
+++ b/src/extension/tab/v4/handler.ts
@@ -333,14 +333,15 @@ function getErrorProperties(error: unknown): EmbeddedExplorerResponse {
   if (isBranded(error, "CombinedGraphQLErrors")) {
     return {
       data: error.data,
-      error,
       errors: error.errors,
       extensions: error.extensions,
     };
   }
 
   if (isErrorLike(error)) {
-    return { error };
+    return {
+      error: { message: error.message, stack: error.stack },
+    };
   }
 
   return {};


### PR DESCRIPTION
Fixes #1721

We were filtering the response from the client based on `dataState` being non-empty, but this meant we were filtering out responses that returned errors since `errorPolicy: none` sets `data` to `undefined`. This fix will ensure the explorer response message is returned when the network status has settled.