### PR TITLE
Exclude test files in bundle

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/__tests__/**/*"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,6 +154,9 @@ export default /** @returns {import("webpack").Configuration} */ (env) => {
         {
           test: /\.(ts)x?$/,
           loader: "ts-loader",
+          options: {
+            configFile: "tsconfig.build.json",
+          },
         },
         {
           test: /\.svg$/i,


### PR DESCRIPTION
#1753 removed test files from `exclude` in order for jest types to load, but this caused test files to be written to the bundle. This adds a separate `tsconfig.build.json` that excludes test files so that they are ignored again.