### PR TITLE
Use temp npm token to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_TMP }}
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
I created a new token valid for 7 days from now to temporarily be able to publish this package. We'll need a more long-term solution soon.