### PR TITLE
Add an extension id for firefox

### DIFF
--- a/src/extension/firefox/manifest.json
+++ b/src/extension/firefox/manifest.json
@@ -26,5 +26,10 @@
       "world": "MAIN"
     }
   ],
-  "manifest_version": 3
+  "manifest_version": 3,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "apolloclientdevtoolsextension@apollographql.com"
+    }
+  }
 }


### PR DESCRIPTION
Firefox manifest v3 requires it: https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/