### PR TITLE
Fix firefox manifest attempt 2

### DIFF
--- a/src/extension/firefox/manifest.json
+++ b/src/extension/firefox/manifest.json
@@ -29,7 +29,7 @@
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {
-      "id": "apolloclientdevtoolsextension@apollographql.com",
+      "id": "{a5260852-8d08-4979-8116-38f1129dfd22}",
       "data_collection_permissions": {
         "required": ["none"]
       }


### PR DESCRIPTION
The `id` in https://github.com/apollographql/apollo-client-devtools/pull/1785 was not correct. This updates to the correct ID. This also adds the necessary `data_collection_permissions` which Firefox needs to accept future updates to the extension.