### PR TITLE
switch over to staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,16 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 26.x
         uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: ">=26.3.0"
 
       - name: Install dependencies
         run: npm ci
+
+      # shim around npm to convert `npm publish` to `npm stage publish` for staged publishing until changesets adds direct support for staged publishing.
+      - run: echo "${{ github.workspace }}/scripts/changesets-wrapper" >> "$GITHUB_PATH"
 
       # Publishes with manifest v2
       - name: Create release PR or publish to npm + GitHub

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -5,14 +5,15 @@
 #
 set -euo pipefail
 
-# we assume that this binary was called because it's the first matching `npm` in PATH,
-# so we remove this directory from PATH and find the real npm binary that way
+# Find the real npm by temporarily excluding this directory from PATH,
+# but do NOT export the modified PATH — child processes (e.g. changeset publish)
+# must still see this wrapper so their own `npm publish` calls get rewritten too.
 SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-export PATH="${PATH//$SELF_DIR:/}"
+REAL_NPM="$(PATH="${PATH//$SELF_DIR:/}" command -v npm)"
 
 if [ "${1:-}" = "publish" ]; then
 	shift
-	exec npm stage publish "$@"
+	exec "$REAL_NPM" stage publish "$@"
 fi
 
-exec npm "$@"
+exec "$REAL_NPM" "$@"

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Shim that rewrites `npm publish ...` to `npm stage publish ...`
+# (https://docs.npmjs.com/staged-publishing) and forwards every other
+# invocation to the real npm unchanged.
+#
+set -euo pipefail
+
+# we assume that this binary was called because it's the first matching `npm` in PATH,
+# so we remove this directory from PATH and find the real npm binary that way
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+export PATH="${PATH//$SELF_DIR:/}"
+
+if [ "${1:-}" = "publish" ]; then
+	shift
+	exec npm stage publish "$@"
+fi
+
+exec npm "$@"


### PR DESCRIPTION
Already applied the necessary changes on the `npm` side:

```json
{
  "type": "github",
  "file": "release.yml",
  "repository": "apollographql/apollo-client-devtools",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/client-devtools-vscode"
}
{
  "type": "github",
  "file": "release.yml",
  "repository": "apollographql/apollo-client-devtools",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "apollo-client-devtools"
}
```